### PR TITLE
fix: fix dividend batch service and refactor test

### DIFF
--- a/batch/src/main/java/nexters/payout/batch/application/DividendBatchService.java
+++ b/batch/src/main/java/nexters/payout/batch/application/DividendBatchService.java
@@ -38,36 +38,32 @@ public class DividendBatchService {
      */
     @Scheduled(cron = "${schedules.cron.dividend}", zone = "UTC")
     public void run() {
-
         List<DividendData> dividendResponses = financialClient.getDividendList();
-
-        for (DividendData response : dividendResponses) {
-
-            Optional<Stock> findStock = stockRepository.findByTicker(response.symbol());
-            if (findStock.isEmpty()) continue;  // NYSE, NASDAQ, AMEX 이외의 주식인 경우 continue
-
-            Optional<Dividend> findDividend =
-                    dividendRepository.findByStockIdAndExDividendDate(
-                            findStock.get().getId(),
-                            parseInstant(response.date())
-                    );
-
-            if (findDividend.isPresent()) {
-                // 기존의 Dividend 엔티티가 존재할 경우 정보 갱신
-                findDividend.get().update(
-                        response.dividend(),
-                        parseInstant(response.paymentDate()),
-                        parseInstant(response.declarationDate()));
-            } else {
-                // 기존의 Dividend 엔티티가 존재하지 않을 경우 새로 생성
-                dividendRepository.save(createDividend(
-                        findStock.get().getId(),
-                        response.dividend(),
-                        parseInstant(response.date()),
-                        parseInstant(response.paymentDate()),
-                        parseInstant(response.declarationDate())));
-            }
+        for (DividendData dividendData : dividendResponses) {
+            stockRepository.findByTicker(dividendData.symbol())
+                    .ifPresent(stock -> handleDividendData(stock, dividendData));
         }
+    }
+    private void handleDividendData(Stock stock, DividendData dividendData) {
+        dividendRepository.findByStockIdAndExDividendDate(stock.getId(), parseInstant(dividendData.date()))
+                .ifPresentOrElse(
+                        existingDividend -> updateDividend(existingDividend, dividendData),
+                        () -> createDividend(stock, dividendData));
+    }
+    private void updateDividend(Dividend existingDividend, DividendData dividendData) {
+        existingDividend.update(
+                dividendData.dividend(),
+                parseInstant(dividendData.paymentDate()),
+                parseInstant(dividendData.declarationDate()));
+    }
+    private void createDividend(Stock stock, DividendData dividendData) {
+        Dividend newDividend = Dividend.createDividend(
+                stock.getId(),
+                dividendData.dividend(),
+                parseInstant(dividendData.date()),
+                parseInstant(dividendData.paymentDate()),
+                parseInstant(dividendData.declarationDate()));
+        dividendRepository.save(newDividend);
     }
 
     /**

--- a/batch/src/main/java/nexters/payout/batch/application/DividendBatchService.java
+++ b/batch/src/main/java/nexters/payout/batch/application/DividendBatchService.java
@@ -36,7 +36,7 @@ public class DividendBatchService {
     /**
      * New York 시간대 기준으로 매일 00:00에 배당금 정보를 갱신하는 스케쥴러 메서드입니다.
      */
-    @Scheduled(cron = "${schedules.cron.dividend}", zone = "America/New_York")
+    @Scheduled(cron = "${schedules.cron.dividend}", zone = "UTC")
     public void run() {
 
         List<DividendData> dividendResponses = financialClient.getDividendList();

--- a/batch/src/main/java/nexters/payout/batch/application/DividendBatchService.java
+++ b/batch/src/main/java/nexters/payout/batch/application/DividendBatchService.java
@@ -46,7 +46,12 @@ public class DividendBatchService {
             Optional<Stock> findStock = stockRepository.findByTicker(response.symbol());
             if (findStock.isEmpty()) continue;  // NYSE, NASDAQ, AMEX 이외의 주식인 경우 continue
 
-            Optional<Dividend> findDividend = dividendRepository.findByStockId(findStock.get().getId());
+            Optional<Dividend> findDividend =
+                    dividendRepository.findByStockIdAndExDividendDate(
+                            findStock.get().getId(),
+                            parseInstant(response.date())
+                    );
+
             if (findDividend.isPresent()) {
                 // 기존의 Dividend 엔티티가 존재할 경우 정보 갱신
                 findDividend.get().update(

--- a/batch/src/main/java/nexters/payout/batch/application/StockBatchService.java
+++ b/batch/src/main/java/nexters/payout/batch/application/StockBatchService.java
@@ -21,7 +21,7 @@ public class StockBatchService {
      * UTC 기준 매일 자정 모든 종목의 현재가와 거래량을 업데이트합니다.
      */
     @Transactional
-    @Scheduled(fixedDelay = 1000000, zone = "UTC")
+    @Scheduled(cron = "${schedules.cron.stock}", zone = "UTC")
     void run() {
         log.info("update stock start..");
         List<FinancialClient.StockData> stockList = financialClient.getLatestStockList();

--- a/batch/src/main/java/nexters/payout/batch/infra/fmp/FmpFinancialClient.java
+++ b/batch/src/main/java/nexters/payout/batch/infra/fmp/FmpFinancialClient.java
@@ -94,12 +94,6 @@ public class FmpFinancialClient implements FinancialClient {
     @Override
     public List<DividendData> getDividendList() {
 
-        WebClient client =
-                WebClient
-                        .builder()
-                        .baseUrl(fmpProperties.getBaseUrl())
-                        .build();
-
         // 3개월 간 총 4번의 데이터를 조회함으로써 기준 날짜로부터 이전 1년 간의 데이터를 조회
         List<DividendData> result = new ArrayList<>();
         for (int i = 0; i < 4; i++) {
@@ -107,7 +101,7 @@ public class FmpFinancialClient implements FinancialClient {
             Instant date = ZonedDateTime.now(ZoneOffset.UTC).minusDays(1).minusMonths(i).toInstant();
 
             List<DividendData> dividendResponses =
-                    client.get()
+                    fmpWebClient.get()
                             .uri(uriBuilder ->
                                     uriBuilder
                                             .path(fmpProperties.getStockDividendCalenderPath())

--- a/batch/src/test/java/nexters/payout/batch/application/DividendBatchServiceTest.java
+++ b/batch/src/test/java/nexters/payout/batch/application/DividendBatchServiceTest.java
@@ -110,9 +110,8 @@ class DividendBatchServiceTest extends AbstractBatchServiceTest {
         assertThat(dividendRepository.findByStockId(stock.getId())).isPresent();
         assertThat(dividendRepository.findByStockId(stock.getId()).get().getDividend()).isEqualTo(dividend.getDividend());
         assertThat(dividendRepository.findByStockId(stock.getId()).get().getExDividendDate()).isEqualTo(dividend.getExDividendDate());
-//        TODO (갑자기 아래 테스트가 깨져요! 로직상 원래 실패했어야 맞는 것 같은데 갑자기 실패하는게 이상해서 확인 부탁드립니다!)
-//        assertThat(dividendRepository.findByStockId(stock.getId()).get().getPaymentDate()).isEqualTo(dividend.getPaymentDate());
-//        assertThat(dividendRepository.findByStockId(stock.getId()).get().getDeclarationDate()).isEqualTo(dividend.getDeclarationDate());
+        assertThat(dividendRepository.findByStockId(stock.getId()).get().getPaymentDate()).isEqualTo(Instant.parse("2023-12-23T00:00:00Z"));
+        assertThat(dividendRepository.findByStockId(stock.getId()).get().getDeclarationDate()).isEqualTo(Instant.parse("2023-12-22T00:00:00Z"));
         assertThat(dividendRepository.findAll().size()).isEqualTo(1);
     }
 }

--- a/batch/src/test/java/nexters/payout/batch/application/DividendBatchServiceTest.java
+++ b/batch/src/test/java/nexters/payout/batch/application/DividendBatchServiceTest.java
@@ -86,11 +86,6 @@ class DividendBatchServiceTest extends AbstractBatchServiceTest {
         dividendBatchService.run();
 
         // then
-        assertThat(dividendRepository.findByStockIdAndExDividendDate(
-                stock.getId(),
-                Instant.parse("2023-12-21T00:00:00Z")))
-                .isPresent();
-
         Dividend actual = dividendRepository.findByStockIdAndExDividendDate(
                         stock.getId(),
                         Instant.parse("2023-12-21T00:00:00Z"))

--- a/batch/src/test/java/nexters/payout/batch/application/DividendBatchServiceTest.java
+++ b/batch/src/test/java/nexters/payout/batch/application/DividendBatchServiceTest.java
@@ -60,9 +60,20 @@ class DividendBatchServiceTest extends AbstractBatchServiceTest {
         dividendBatchService.run();
 
         // then
-        assertThat(dividendRepository.findByStockId(stock.getId())).isPresent();
-        assertThat(dividendRepository.findByStockId(stock.getId()).get().getDividend()).isEqualTo(dividend.getDividend());
-        assertThat(dividendRepository.findByStockId(stock.getId()).get().getExDividendDate()).isEqualTo(dividend.getExDividendDate());
+        assertThat(dividendRepository.findByStockIdAndExDividendDate(
+                        stock.getId(),
+                        Instant.parse("2023-12-21T00:00:00Z")))
+                .isPresent();
+        assertThat(dividendRepository.findByStockIdAndExDividendDate(
+                        stock.getId(),
+                        Instant.parse("2023-12-21T00:00:00Z"))
+                .get().getDividend())
+                .isEqualTo(dividend.getDividend());
+        assertThat(dividendRepository.findByStockIdAndExDividendDate(
+                        stock.getId(),
+                        Instant.parse("2023-12-21T00:00:00Z"))
+                .get().getExDividendDate())
+                .isEqualTo(dividend.getExDividendDate());
         assertThat(dividendRepository.findAll().size()).isEqualTo(1);
     }
 
@@ -107,11 +118,31 @@ class DividendBatchServiceTest extends AbstractBatchServiceTest {
         dividendBatchService.run();
 
         // then
-        assertThat(dividendRepository.findByStockId(stock.getId())).isPresent();
-        assertThat(dividendRepository.findByStockId(stock.getId()).get().getDividend()).isEqualTo(dividend.getDividend());
-        assertThat(dividendRepository.findByStockId(stock.getId()).get().getExDividendDate()).isEqualTo(dividend.getExDividendDate());
-        assertThat(dividendRepository.findByStockId(stock.getId()).get().getPaymentDate()).isEqualTo(Instant.parse("2023-12-23T00:00:00Z"));
-        assertThat(dividendRepository.findByStockId(stock.getId()).get().getDeclarationDate()).isEqualTo(Instant.parse("2023-12-22T00:00:00Z"));
-        assertThat(dividendRepository.findAll().size()).isEqualTo(1);
+        assertThat(dividendRepository.findByStockIdAndExDividendDate(
+                        stock.getId(),
+                        Instant.parse("2023-12-21T00:00:00Z")))
+                .isPresent();
+        assertThat(dividendRepository.findByStockIdAndExDividendDate(
+                        stock.getId(),
+                        Instant.parse("2023-12-21T00:00:00Z"))
+                .get().getDividend())
+                .isEqualTo(dividend.getDividend());
+        assertThat(dividendRepository.findByStockIdAndExDividendDate(
+                        stock.getId(),
+                        Instant.parse("2023-12-21T00:00:00Z"))
+                .get().getExDividendDate())
+                .isEqualTo(dividend.getExDividendDate());
+        assertThat(dividendRepository.findByStockIdAndExDividendDate(
+                        stock.getId(),
+                        Instant.parse("2023-12-21T00:00:00Z"))
+                .get().getPaymentDate())
+                .isEqualTo(Instant.parse("2023-12-23T00:00:00Z"));
+        assertThat(dividendRepository.findByStockIdAndExDividendDate(
+                        stock.getId(),
+                        Instant.parse("2023-12-21T00:00:00Z"))
+                .get().getDeclarationDate())
+                .isEqualTo(Instant.parse("2023-12-22T00:00:00Z"));
+        assertThat(dividendRepository.findAll().size())
+                .isEqualTo(1);
     }
 }

--- a/batch/src/test/java/nexters/payout/batch/application/DividendBatchServiceTest.java
+++ b/batch/src/test/java/nexters/payout/batch/application/DividendBatchServiceTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import static nexters.payout.domain.dividend.Dividend.createDividend;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.doReturn;
 
 @DisplayName("배당금 스케쥴러 서비스 테스트")
@@ -60,21 +61,23 @@ class DividendBatchServiceTest extends AbstractBatchServiceTest {
         dividendBatchService.run();
 
         // then
-        assertThat(dividendRepository.findByStockIdAndExDividendDate(
+        assertAll(
+                () -> assertThat(dividendRepository.findByStockIdAndExDividendDate(
                         stock.getId(),
                         Instant.parse("2023-12-21T00:00:00Z")))
-                .isPresent();
-        assertThat(dividendRepository.findByStockIdAndExDividendDate(
-                        stock.getId(),
-                        Instant.parse("2023-12-21T00:00:00Z"))
-                .get().getDividend())
-                .isEqualTo(dividend.getDividend());
-        assertThat(dividendRepository.findByStockIdAndExDividendDate(
-                        stock.getId(),
-                        Instant.parse("2023-12-21T00:00:00Z"))
-                .get().getExDividendDate())
-                .isEqualTo(dividend.getExDividendDate());
-        assertThat(dividendRepository.findAll().size()).isEqualTo(1);
+                        .isPresent(),
+                () -> assertThat(dividendRepository.findByStockIdAndExDividendDate(
+                                stock.getId(),
+                                Instant.parse("2023-12-21T00:00:00Z"))
+                        .get().getDividend())
+                        .isEqualTo(dividend.getDividend()),
+                () -> assertThat(dividendRepository.findByStockIdAndExDividendDate(
+                                stock.getId(),
+                                Instant.parse("2023-12-21T00:00:00Z"))
+                        .get().getExDividendDate())
+                        .isEqualTo(dividend.getExDividendDate()),
+                () -> assertThat(dividendRepository.findAll().size()).isEqualTo(1)
+        );
     }
 
     @Test
@@ -118,31 +121,33 @@ class DividendBatchServiceTest extends AbstractBatchServiceTest {
         dividendBatchService.run();
 
         // then
-        assertThat(dividendRepository.findByStockIdAndExDividendDate(
+        assertAll(
+                () -> assertThat(dividendRepository.findByStockIdAndExDividendDate(
                         stock.getId(),
                         Instant.parse("2023-12-21T00:00:00Z")))
-                .isPresent();
-        assertThat(dividendRepository.findByStockIdAndExDividendDate(
-                        stock.getId(),
-                        Instant.parse("2023-12-21T00:00:00Z"))
-                .get().getDividend())
-                .isEqualTo(dividend.getDividend());
-        assertThat(dividendRepository.findByStockIdAndExDividendDate(
-                        stock.getId(),
-                        Instant.parse("2023-12-21T00:00:00Z"))
-                .get().getExDividendDate())
-                .isEqualTo(dividend.getExDividendDate());
-        assertThat(dividendRepository.findByStockIdAndExDividendDate(
-                        stock.getId(),
-                        Instant.parse("2023-12-21T00:00:00Z"))
-                .get().getPaymentDate())
-                .isEqualTo(Instant.parse("2023-12-23T00:00:00Z"));
-        assertThat(dividendRepository.findByStockIdAndExDividendDate(
-                        stock.getId(),
-                        Instant.parse("2023-12-21T00:00:00Z"))
-                .get().getDeclarationDate())
-                .isEqualTo(Instant.parse("2023-12-22T00:00:00Z"));
-        assertThat(dividendRepository.findAll().size())
-                .isEqualTo(1);
+                        .isPresent(),
+                () -> assertThat(dividendRepository.findByStockIdAndExDividendDate(
+                                stock.getId(),
+                                Instant.parse("2023-12-21T00:00:00Z"))
+                        .get().getDividend())
+                        .isEqualTo(dividend.getDividend()),
+                () -> assertThat(dividendRepository.findByStockIdAndExDividendDate(
+                                stock.getId(),
+                                Instant.parse("2023-12-21T00:00:00Z"))
+                        .get().getExDividendDate())
+                        .isEqualTo(dividend.getExDividendDate()),
+                () -> assertThat(dividendRepository.findByStockIdAndExDividendDate(
+                                stock.getId(),
+                                Instant.parse("2023-12-21T00:00:00Z"))
+                        .get().getPaymentDate())
+                        .isEqualTo(Instant.parse("2023-12-23T00:00:00Z")),
+                () -> assertThat(dividendRepository.findByStockIdAndExDividendDate(
+                                stock.getId(),
+                                Instant.parse("2023-12-21T00:00:00Z"))
+                        .get().getDeclarationDate())
+                        .isEqualTo(Instant.parse("2023-12-22T00:00:00Z")),
+                () -> assertThat(dividendRepository.findAll().size())
+                        .isEqualTo(1)
+        );
     }
 }

--- a/batch/src/test/java/nexters/payout/batch/application/StockBatchServiceTest.java
+++ b/batch/src/test/java/nexters/payout/batch/application/StockBatchServiceTest.java
@@ -20,8 +20,8 @@ class StockBatchServiceTest extends AbstractBatchServiceTest {
     void 현재가와_거래량을_업데이트한다() {
         // given
         Stock stock = stockRepository.save(StockFixture.createStock(StockFixture.TESLA, 10.0, 1234));
-        FinancialClient.StockData stockData = LatestStockFixture.createStockData(stock.getTicker(), 30.0, 4321);
-        given(financialClient.getLatestStockList()).willReturn(List.of(stockData));
+        FinancialClient.StockData expected = LatestStockFixture.createStockData(stock.getTicker(), 30.0, 4321);
+        given(financialClient.getLatestStockList()).willReturn(List.of(expected));
 
         // when
         stockBatchService.run();
@@ -29,8 +29,8 @@ class StockBatchServiceTest extends AbstractBatchServiceTest {
         // then
         Stock actual = stockRepository.findByTicker(stock.getTicker()).get();
         assertAll(
-                () -> assertThat(actual.getPrice()).isEqualTo(stockData.price()),
-                () -> assertThat(actual.getVolume()).isEqualTo(stockData.volume())
+                () -> assertThat(actual.getPrice()).isEqualTo(expected.price()),
+                () -> assertThat(actual.getVolume()).isEqualTo(expected.volume())
         );
     }
 }

--- a/domain/src/main/java/nexters/payout/domain/dividend/repository/DividendRepository.java
+++ b/domain/src/main/java/nexters/payout/domain/dividend/repository/DividendRepository.java
@@ -3,6 +3,7 @@ package nexters.payout.domain.dividend.repository;
 import nexters.payout.domain.dividend.Dividend;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -13,5 +14,5 @@ import java.util.UUID;
  */
 public interface DividendRepository extends JpaRepository<Dividend, UUID>, DividendRepositoryCustom {
 
-    Optional<Dividend> findByStockId(UUID stockId);
+    Optional<Dividend> findByStockIdAndExDividendDate(UUID stockId, Instant exDividendDate);
 }

--- a/domain/src/testFixtures/java/nexters/payout/domain/DividendFixture.java
+++ b/domain/src/testFixtures/java/nexters/payout/domain/DividendFixture.java
@@ -1,0 +1,28 @@
+package nexters.payout.domain;
+
+import nexters.payout.domain.dividend.Dividend;
+
+import java.time.Instant;
+import java.util.UUID;
+
+
+public class DividendFixture {
+
+    public static Dividend createDividend(UUID stockId) {
+        return Dividend.createDividend(
+                stockId,
+                12.21,
+                Instant.parse("2023-12-21T00:00:00Z"),
+                Instant.parse("2023-12-23T00:00:00Z"),
+                Instant.parse("2023-12-22T00:00:00Z"));
+    }
+
+    public static Dividend createDividendWithNullDate(UUID stockId) {
+        return Dividend.createDividend(
+                stockId,
+                12.21,
+                Instant.parse("2023-12-21T00:00:00Z"),
+                null,
+                null);
+    }
+}


### PR DESCRIPTION
### Issue Number

close: #18 

### 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] dividend batch 서비스에서 기존의 배당금 엔티티를 찾는 로직의 버그 수정 (stockId로만 조회 -> stockId, ex-dividend date로 조회)
- [x] 테스트 로직 수정

### 변경사항

- 의존성 목록

### PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

