### PR TITLE
feat: update sector information

### DIFF
--- a/api-server/src/main/java/nexters/payout/apiserver/stock/application/StockQueryService.java
+++ b/api-server/src/main/java/nexters/payout/apiserver/stock/application/StockQueryService.java
@@ -43,27 +43,11 @@ public class StockQueryService {
         List<Month> dividendMonths = dividendAnalysisService.calculateDividendMonths(stock, lastYearDividends);
         Double dividendYield = dividendAnalysisService.calculateDividendYield(stock, lastYearDividends);
 
-        return findEarliestDividendThisYear(lastYearDividends)
+        return dividendAnalysisService.findEarliestDividendThisYear(lastYearDividends)
                 .map(dividend -> StockDetailResponse.of(stock, dividend, dividendMonths, dividendYield))
                 .orElseGet(() -> StockDetailResponse.from(stock));
     }
 
-    /**
-     * 작년 1년간 데이터를 기준으로 가장 가까운 예상 배당금을 조회합니다.
-     */
-    public Optional<Dividend> findEarliestDividendThisYear(final List<Dividend> lastYearDividends) {
-        int thisYear = InstantProvider.getThisYear();
-
-        return lastYearDividends
-                .stream()
-                .map(dividend -> {
-                    LocalDate paymentDate = InstantProvider.toLocalDate(dividend.getPaymentDate());
-                    LocalDate adjustedPaymentDate = paymentDate.withYear(thisYear);
-                    return new AbstractMap.SimpleEntry<>(dividend, adjustedPaymentDate);
-                })
-                .min(Map.Entry.comparingByValue())
-                .map(Map.Entry::getKey);
-    }
 
     private List<Dividend> getLastYearDividends(Stock stock) {
         int lastYear = InstantProvider.getLastYear();

--- a/api-server/src/main/java/nexters/payout/apiserver/stock/application/StockQueryService.java
+++ b/api-server/src/main/java/nexters/payout/apiserver/stock/application/StockQueryService.java
@@ -19,10 +19,9 @@ import nexters.payout.domain.stock.domain.service.SectorAnalysisService.StockSha
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
 import java.time.Month;
-import java.util.*;
-import java.util.stream.Collector;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -68,32 +67,12 @@ public class StockQueryService {
 
     private List<StockShare> getStockShares(final SectorRatioRequest request) {
         List<Stock> stocks = stockRepository.findAllByTickerIn(getTickers(request));
-        Map<UUID, Dividend> stockDividendMap = getStockDividendMap(getStockIds(stocks));
 
         return stocks.stream()
                 .map(stock -> new StockShare(
                         stock,
-                        stockDividendMap.get(stock.getId()),
                         getTickerShareMap(request).get(stock.getTicker())))
                 .collect(Collectors.toList());
-    }
-
-    private List<UUID> getStockIds(final List<Stock> stocks) {
-        return stocks.stream()
-                .map(Stock::getId)
-                .toList();
-    }
-
-    private Map<UUID, Dividend> getStockDividendMap(final List<UUID> stockIds) {
-        return dividendRepository.findAllByStockIdIn(stockIds)
-                .stream()
-                .collect(Collectors.groupingBy(Dividend::getStockId, getLatestDividendOrNull()));
-    }
-
-    private Collector<Dividend, Object, Dividend> getLatestDividendOrNull() {
-        return Collectors.collectingAndThen(
-                Collectors.maxBy(Comparator.comparing(Dividend::getDeclarationDate)),
-                optionalDividend -> optionalDividend.orElse(null));
     }
 
     private List<String> getTickers(final SectorRatioRequest request) {

--- a/api-server/src/main/java/nexters/payout/apiserver/stock/application/dto/response/SectorRatioResponse.java
+++ b/api-server/src/main/java/nexters/payout/apiserver/stock/application/dto/response/SectorRatioResponse.java
@@ -21,7 +21,7 @@ public record SectorRatioResponse(
                         entry.getValue()
                                 .stockShares()
                                 .stream()
-                                .map(stockShare -> StockResponse.of(stockShare.stock(), stockShare.dividend()))
+                                .map(stockShare -> StockResponse.from(stockShare.stock()))
                                 .collect(Collectors.toList()))
                 )
                 .collect(Collectors.toList());

--- a/api-server/src/main/java/nexters/payout/apiserver/stock/application/dto/response/StockResponse.java
+++ b/api-server/src/main/java/nexters/payout/apiserver/stock/application/dto/response/StockResponse.java
@@ -13,10 +13,9 @@ public record StockResponse(
         String exchange,
         String industry,
         Double price,
-        Integer volume,
-        Double dividendPerShare
+        Integer volume
 ) {
-    public static StockResponse of(Stock stock, Dividend dividend) {
+    public static StockResponse from(Stock stock) {
         return new StockResponse(
                 stock.getId(),
                 stock.getTicker(),
@@ -25,8 +24,7 @@ public record StockResponse(
                 stock.getExchange(),
                 stock.getIndustry(),
                 stock.getPrice(),
-                stock.getVolume(),
-                dividend == null ? null : dividend.getDividend()
+                stock.getVolume()
         );
     }
 }

--- a/api-server/src/test/java/nexters/payout/apiserver/stock/application/StockQueryServiceTest.java
+++ b/api-server/src/test/java/nexters/payout/apiserver/stock/application/StockQueryServiceTest.java
@@ -99,13 +99,9 @@ class StockQueryServiceTest {
         SectorRatioRequest request = new SectorRatioRequest(List.of(new TickerShare(AAPL, 2), new TickerShare(TSLA, 3)));
         Stock appl = StockFixture.createStock(AAPL, Sector.TECHNOLOGY, 4.0);
         Stock tsla = StockFixture.createStock(TSLA, Sector.CONSUMER_CYCLICAL, 2.2);
-        Dividend aaplDiv = DividendFixture.createDividend(appl.getId(), 11.0);
-        Dividend tslaDiv = DividendFixture.createDividend(tsla.getId(), 5.0);
         List<Stock> stocks = List.of(appl, tsla);
-        List<Dividend> dividends = List.of(aaplDiv, tslaDiv);
 
         given(stockRepository.findAllByTickerIn(any())).willReturn(stocks);
-        given(dividendRepository.findAllByStockIdIn(any())).willReturn(dividends);
 
         List<SectorRatioResponse> expected = List.of(
                 new SectorRatioResponse(
@@ -119,23 +115,22 @@ class StockQueryServiceTest {
                                 appl.getExchange(),
                                 appl.getIndustry(),
                                 appl.getPrice(),
-                                appl.getVolume(),
-                                aaplDiv.getDividend()
+                                appl.getVolume()
                         ))
                 ),
                 new SectorRatioResponse(
                         Sector.CONSUMER_CYCLICAL.getName(),
                         0.4520547945205479,
                         List.of(new StockResponse(
-                                tsla.getId(),
-                                tsla.getTicker(),
-                                tsla.getName(),
-                                tsla.getSector().getName(),
-                                tsla.getExchange(),
-                                tsla.getIndustry(),
-                                tsla.getPrice(),
-                                tsla.getVolume(),
-                                tslaDiv.getDividend())
+                                        tsla.getId(),
+                                        tsla.getTicker(),
+                                        tsla.getName(),
+                                        tsla.getSector().getName(),
+                                        tsla.getExchange(),
+                                        tsla.getIndustry(),
+                                        tsla.getPrice(),
+                                        tsla.getVolume()
+                                )
                         )
                 )
         );

--- a/api-server/src/test/java/nexters/payout/apiserver/stock/presentation/integration/StockControllerTest.java
+++ b/api-server/src/test/java/nexters/payout/apiserver/stock/presentation/integration/StockControllerTest.java
@@ -46,7 +46,7 @@ class StockControllerTest extends IntegrationTest {
     }
 
     @Test
-    void 종목_조회시_배당금이_존재하지_않는_경우_정상적으로_조회된다() {
+    void 종목_조회시_종목의_정보가_정상적으로_조회된다() {
         // given
         stockRepository.save(StockFixture.createStock(TSLA, Sector.CONSUMER_CYCLICAL));
 
@@ -65,36 +65,6 @@ class StockControllerTest extends IntegrationTest {
         assertAll(
                 () -> assertThat(stockDetailResponse.ticker()).isEqualTo(TSLA),
                 () -> assertThat(stockDetailResponse.sectorName()).isEqualTo(Sector.CONSUMER_CYCLICAL.getName())
-        );
-    }
-
-    @Test
-    void 종목_조회시_배당금이_존재하는_경우_정상적으로_조회된다() {
-        // given
-        Double price = 100.0;
-        Double dividend = 12.0;
-        Stock tsla = stockRepository.save(StockFixture.createStock(TSLA, Sector.CONSUMER_CYCLICAL, price));
-        Instant paymentDate = LocalDate.of(2023, 4, 5).atStartOfDay().toInstant(UTC);
-        dividendRepository.save(DividendFixture.createDividend(tsla.getId(), dividend, paymentDate));
-
-        // when, then
-        StockDetailResponse stockDetailResponse = RestAssured
-                .given()
-                .log().all()
-                .contentType(ContentType.JSON)
-                .when().get("api/stocks/TSLA")
-                .then().log().all()
-                .statusCode(200)
-                .extract()
-                .as(new TypeRef<>() {
-                });
-
-        assertAll(
-                () -> assertThat(stockDetailResponse.ticker()).isEqualTo(TSLA),
-                () -> assertThat(stockDetailResponse.sectorName()).isEqualTo(Sector.CONSUMER_CYCLICAL.getName()),
-                () -> assertThat(stockDetailResponse.dividendYield()).isEqualTo(dividend / price),
-                () -> assertThat(stockDetailResponse.earliestPaymentDate()).isEqualTo(LocalDate.of(LocalDate.now().getYear(), 4, 5)),
-                () -> assertThat(stockDetailResponse.dividendMonths()).isEqualTo(List.of(Month.APRIL))
         );
     }
 

--- a/api-server/src/test/java/nexters/payout/apiserver/stock/presentation/integration/StockControllerTest.java
+++ b/api-server/src/test/java/nexters/payout/apiserver/stock/presentation/integration/StockControllerTest.java
@@ -188,7 +188,6 @@ class StockControllerTest extends IntegrationTest {
         // given
         SectorRatioRequest request = new SectorRatioRequest(List.of(new TickerShare(AAPL, 2)));
         Stock stock = stockRepository.save(StockFixture.createStock(AAPL, Sector.TECHNOLOGY, 5.0));
-        dividendRepository.save(DividendFixture.createDividend(stock.getId(), 12.0));
 
         // when
         List<SectorRatioResponse> actual = RestAssured
@@ -208,8 +207,7 @@ class StockControllerTest extends IntegrationTest {
                 () -> assertThat(actual).hasSize(1),
                 () -> assertThat(actual.get(0).sectorName()).isEqualTo("Technology"),
                 () -> assertThat(actual.get(0).sectorRatio()).isEqualTo(1.0),
-                () -> assertThat(actual.get(0).stocks().get(0).ticker()).isEqualTo(AAPL),
-                () -> assertThat(actual.get(0).stocks().get(0).dividendPerShare()).isEqualTo(12.0)
+                () -> assertThat(actual.get(0).stocks().get(0).ticker()).isEqualTo(AAPL)
         );
     }
 
@@ -237,8 +235,7 @@ class StockControllerTest extends IntegrationTest {
                 () -> assertThat(actual).hasSize(1),
                 () -> assertThat(actual.get(0).sectorName()).isEqualTo("Technology"),
                 () -> assertThat(actual.get(0).sectorRatio()).isEqualTo(1.0),
-                () -> assertThat(actual.get(0).stocks().get(0).ticker()).isEqualTo(AAPL),
-                () -> assertThat(actual.get(0).stocks().get(0).dividendPerShare()).isEqualTo(null)
+                () -> assertThat(actual.get(0).stocks().get(0).ticker()).isEqualTo(AAPL)
         );
     }
 }

--- a/batch/src/main/java/nexters/payout/batch/application/FinancialClient.java
+++ b/batch/src/main/java/nexters/payout/batch/application/FinancialClient.java
@@ -28,7 +28,7 @@ public interface FinancialClient {
     }
 
     record DividendData(
-            Instant date,
+            Instant exDividendDate,
             String label,
             Double adjDividend,
             String symbol,

--- a/batch/src/main/java/nexters/payout/batch/application/StockBatchService.java
+++ b/batch/src/main/java/nexters/payout/batch/application/StockBatchService.java
@@ -2,17 +2,12 @@ package nexters.payout.batch.application;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import nexters.payout.core.exception.error.NotFoundException;
-import nexters.payout.domain.stock.application.StockCommandService;
-import nexters.payout.domain.stock.application.dto.UpdateStockRequest;
-import nexters.payout.domain.stock.domain.Stock;
-import nexters.payout.domain.stock.domain.repository.StockRepository;
 import nexters.payout.batch.application.FinancialClient.StockData;
+import nexters.payout.domain.stock.application.StockCommandService;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.UUID;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -20,32 +15,25 @@ import java.util.UUID;
 public class StockBatchService {
 
     private final FinancialClient financialClient;
-    private final StockRepository stockRepository;
     private final StockCommandService stockCommandService;
 
     /**
      * UTC 시간대 기준 매일 자정 모든 종목의 현재가와 거래량을 업데이트합니다.
      */
-    @Scheduled(cron = "${schedules.cron.stock}", zone = "UTC")
+    @Scheduled(fixedDelay = 10000000, zone = "UTC")
     void run() {
         log.info("update stock start..");
         List<StockData> stockList = financialClient.getLatestStockList();
 
         for (StockData stockData : stockList) {
-            stockRepository.findByTicker(stockData.ticker())
-                    .ifPresentOrElse(
-                            existing -> update(existing.getTicker(), stockData),
-                            () -> create(stockData)
-                    );
+            try {
+                stockCommandService.saveOrUpdate(stockData.ticker(), stockData.toDomain());
+            } catch (Exception e) {
+                log.error("fail to save(update) stock: " + stockData);
+                log.error(e.getMessage());
+            }
         }
+
         log.info("update stock end..");
-    }
-
-    private void create(final StockData stockData) {
-        stockCommandService.save(stockData.toDomain());
-    }
-
-    private void update(final String ticker, final StockData stockData) {
-        stockCommandService.update(ticker, new UpdateStockRequest(stockData.price(), stockData.volume()));
     }
 }

--- a/batch/src/main/java/nexters/payout/batch/application/StockBatchService.java
+++ b/batch/src/main/java/nexters/payout/batch/application/StockBatchService.java
@@ -20,7 +20,7 @@ public class StockBatchService {
     /**
      * UTC 시간대 기준 매일 자정 모든 종목의 현재가와 거래량을 업데이트합니다.
      */
-    @Scheduled(fixedDelay = 10000000, zone = "UTC")
+    @Scheduled(cron = "${schedules.cron.stock}", zone = "UTC")
     void run() {
         log.info("update stock start..");
         List<StockData> stockList = financialClient.getLatestStockList();

--- a/batch/src/main/java/nexters/payout/batch/infra/fmp/FmpFinancialClient.java
+++ b/batch/src/main/java/nexters/payout/batch/infra/fmp/FmpFinancialClient.java
@@ -41,7 +41,8 @@ public class FmpFinancialClient implements FinancialClient {
                 .flatMap(exchange -> fetchVolumeList(exchange).stream())
                 .collect(Collectors.toMap(FmpVolumeData::symbol, fmpVolumeData -> fmpVolumeData));
 
-        return stockDataMap.entrySet().stream()
+        return stockDataMap.entrySet()
+                .stream()
                 .map(entry -> {
                     String tickerName = entry.getKey();
                     FmpStockData fmpStockData = entry.getValue();
@@ -62,7 +63,7 @@ public class FmpFinancialClient implements FinancialClient {
                 .toList();
     }
 
-    private List<FmpStockData> fetchStockList(String sector) {
+    private List<FmpStockData> fetchStockList(final String sector) {
         return fmpWebClient.get()
                 .uri(uriBuilder -> uriBuilder
                         .path(fmpProperties.getStockScreenerPath())

--- a/batch/src/main/resources/application.yml
+++ b/batch/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 spring:
   profiles:
-    active: test
+    active: dev
 
 

--- a/domain/src/main/java/nexters/payout/domain/dividend/application/DividendCommandService.java
+++ b/domain/src/main/java/nexters/payout/domain/dividend/application/DividendCommandService.java
@@ -5,6 +5,7 @@ import nexters.payout.core.exception.error.NotFoundException;
 import nexters.payout.domain.dividend.application.dto.UpdateDividendRequest;
 import nexters.payout.domain.dividend.domain.Dividend;
 import nexters.payout.domain.dividend.domain.repository.DividendRepository;
+import nexters.payout.domain.stock.domain.Stock;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,15 +15,19 @@ import java.util.UUID;
 @RequiredArgsConstructor
 @Transactional
 public class DividendCommandService {
+
     private final DividendRepository dividendRepository;
 
-    public void save(Dividend dividend) {
-        dividendRepository.save(dividend);
-    }
+    public void saveOrUpdate(UUID stockId, Dividend dividendData) {
+        dividendRepository.findByStockIdAndExDividendDate(stockId, dividendData.getExDividendDate())
+                .ifPresentOrElse(
+                        existing -> existing.update(
+                                dividendData.getDividend(),
+                                dividendData.getPaymentDate(),
+                                dividendData.getDeclarationDate()
+                        ),
+                        () -> dividendRepository.save(dividendData)
+                );
 
-    public void update(UUID dividendId, UpdateDividendRequest request) {
-        Dividend dividend = dividendRepository.findById(dividendId)
-                .orElseThrow(() -> new NotFoundException(String.format("not found dividend [%s]", dividendId)));
-        dividend.update(request.dividend(), request.paymentDate(), request.declarationDate());
     }
 }

--- a/domain/src/main/java/nexters/payout/domain/stock/application/StockCommandService.java
+++ b/domain/src/main/java/nexters/payout/domain/stock/application/StockCommandService.java
@@ -1,27 +1,23 @@
 package nexters.payout.domain.stock.application;
 
 import lombok.RequiredArgsConstructor;
-import nexters.payout.core.exception.error.NotFoundException;
-import nexters.payout.domain.stock.application.dto.UpdateStockRequest;
 import nexters.payout.domain.stock.domain.Stock;
 import nexters.payout.domain.stock.domain.repository.StockRepository;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class StockCommandService {
+
     private final StockRepository stockRepository;
 
-    public void save(Stock stock) {
-        stockRepository.save(stock);
-    }
-
-    public void update(String ticker, UpdateStockRequest request) {
-        Stock stock = stockRepository.findByTicker(ticker)
-                .orElseThrow(() -> new NotFoundException(String.format("not found ticker [%s]", ticker)));
-        stock.update(request.price(), request.volume());
+    public void saveOrUpdate(String ticker, Stock stockData) {
+        stockRepository.findByTicker(ticker)
+                .ifPresentOrElse(
+                        existing -> existing.update(stockData.getPrice(), stockData.getVolume()),
+                        () -> stockRepository.save(stockData)
+                );
     }
 }

--- a/domain/src/main/java/nexters/payout/domain/stock/domain/Sector.java
+++ b/domain/src/main/java/nexters/payout/domain/stock/domain/Sector.java
@@ -4,6 +4,10 @@ import lombok.Getter;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Getter
 public enum Sector {
@@ -30,18 +34,27 @@ public enum Sector {
         this.name = name;
     }
 
+    private static final Map<String, Sector> NAME_TO_SECTOR_MAP = Arrays.stream(values())
+            .collect(Collectors.toMap(sector -> sector.name, Function.identity()));
+
+    private static final Set<String> ETC_NAMES = Set.of(FINANCIAL.name, SERVICES.name, CONGLOMERATES.name);
+
     public static List<String> getNames() {
         return Arrays.stream(Sector.values())
                 .map(it -> it.name)
+                .filter(name -> !name.isEmpty())
                 .toList();
     }
 
     public static Sector fromValue(String value) {
-        for (Sector sector : Sector.values()) {
-            if (sector.getName().equalsIgnoreCase(value)) {
-                return sector;
-            }
+        if (isEtcCategory(value)) {
+            return ETC;
         }
-        return ETC;
+
+        return NAME_TO_SECTOR_MAP.getOrDefault(value.toUpperCase(), ETC);
+    }
+
+    private static boolean isEtcCategory(String value) {
+        return ETC_NAMES.contains(value);
     }
 }

--- a/domain/src/main/java/nexters/payout/domain/stock/domain/service/DividendAnalysisService.java
+++ b/domain/src/main/java/nexters/payout/domain/stock/domain/service/DividendAnalysisService.java
@@ -7,13 +7,16 @@ import nexters.payout.domain.stock.domain.Stock;
 
 import java.time.LocalDate;
 import java.time.Month;
+import java.util.AbstractMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @DomainService
 public class DividendAnalysisService {
     /**
-     * 작년 1월 ~ 12월을 기준으로 배당을 주었던 월 리스트를 계산합니다.
+     * 작년 데이터를 기반으로 배당을 주었던 월 리스트를 계산합니다.
      */
     public List<Month> calculateDividendMonths(final Stock stock, final List<Dividend> dividends) {
         int lastYear = InstantProvider.getLastYear();
@@ -27,8 +30,14 @@ public class DividendAnalysisService {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * 배당 수익률은 (연간 배당금 / 현재가) 를 기준으로 합니다.
+     */
     public Double calculateDividendYield(final Stock stock, final List<Dividend> dividends) {
-        double sumOfDividend = dividends.stream().mapToDouble(Dividend::getDividend).sum();
+        double sumOfDividend = dividends.stream()
+                .mapToDouble(Dividend::getDividend)
+                .sum();
+
         Double stockPrice = stock.getPrice();
 
         if (stockPrice == null || stockPrice == 0) {
@@ -36,5 +45,22 @@ public class DividendAnalysisService {
         }
 
         return sumOfDividend / stockPrice;
+    }
+
+    /**
+     * 작년 데이터를 기반으로 가장 빠른 배당 지급일을 계산합니다.
+     */
+    public Optional<Dividend> findEarliestDividendThisYear(final List<Dividend> lastYearDividends) {
+        int thisYear = InstantProvider.getThisYear();
+
+        return lastYearDividends
+                .stream()
+                .map(dividend -> {
+                    LocalDate paymentDate = InstantProvider.toLocalDate(dividend.getPaymentDate());
+                    LocalDate adjustedPaymentDate = paymentDate.withYear(thisYear);
+                    return new AbstractMap.SimpleEntry<>(dividend, adjustedPaymentDate);
+                })
+                .min(Map.Entry.comparingByValue())
+                .map(Map.Entry::getKey);
     }
 }

--- a/domain/src/main/java/nexters/payout/domain/stock/domain/service/SectorAnalysisService.java
+++ b/domain/src/main/java/nexters/payout/domain/stock/domain/service/SectorAnalysisService.java
@@ -76,7 +76,6 @@ public class SectorAnalysisService {
 
     public record StockShare(
             Stock stock,
-            Dividend dividend,
             Integer share
     ) {
 

--- a/domain/src/test/java/nexters/payout/domain/stock/service/SectorAnalysisServiceTest.java
+++ b/domain/src/test/java/nexters/payout/domain/stock/service/SectorAnalysisServiceTest.java
@@ -21,7 +21,7 @@ class SectorAnalysisServiceTest {
     void 하나의_티커가_존재하는_경우_섹터비율_검증() {
         // given
         Stock stock = StockFixture.createStock(StockFixture.AAPL, Sector.TECHNOLOGY, 3.0);
-        List<StockShare> stockShares = List.of(new StockShare(stock, null, 1));
+        List<StockShare> stockShares = List.of(new StockShare(stock, 1));
         SectorAnalysisService sectorAnalysisService = new SectorAnalysisService();
 
         // when
@@ -30,7 +30,7 @@ class SectorAnalysisServiceTest {
         // then
         assertAll(
                 () -> assertThat(actual).hasSize(1),
-                () -> assertThat(actual.get(Sector.TECHNOLOGY)).isEqualTo(new SectorInfo(1.0, List.of(new StockShare(stock, null, 1))))
+                () -> assertThat(actual.get(Sector.TECHNOLOGY)).isEqualTo(new SectorInfo(1.0, List.of(new StockShare(stock, 1))))
         );
     }
 
@@ -39,7 +39,7 @@ class SectorAnalysisServiceTest {
         // given
         Stock appl = StockFixture.createStock(StockFixture.AAPL, Sector.TECHNOLOGY, 4.0);
         Stock tsla = StockFixture.createStock(StockFixture.TSLA, Sector.CONSUMER_CYCLICAL, 1.0);
-        List<StockShare> stockShares = List.of(new StockShare(appl, null, 2), new StockShare(tsla, null, 1));
+        List<StockShare> stockShares = List.of(new StockShare(appl, 2), new StockShare(tsla, 1));
         SectorAnalysisService sectorAnalysisService = new SectorAnalysisService();
 
         // when
@@ -52,9 +52,9 @@ class SectorAnalysisServiceTest {
         assertAll(
                 () -> assertThat(actual).hasSize(2),
                 () -> assertThat(actualFinancialSectorInfo.ratio()).isCloseTo(0.8889, within(0.001)),
-                () -> assertThat(actualFinancialSectorInfo.stockShares()).isEqualTo(List.of(new StockShare(appl, null, 2))),
+                () -> assertThat(actualFinancialSectorInfo.stockShares()).isEqualTo(List.of(new StockShare(appl, 2))),
                 () -> assertThat(actualTechnologySectorInfo.ratio()).isCloseTo(0.1111, within(0.001)),
-                () -> assertThat(actualTechnologySectorInfo.stockShares()).isEqualTo(List.of(new StockShare(tsla, null, 1)))
+                () -> assertThat(actualTechnologySectorInfo.stockShares()).isEqualTo(List.of(new StockShare(tsla, 1)))
         );
     }
 }


### PR DESCRIPTION
### Issue Number

close: #27 

### 작업 내역
결정된 섹터 관련 정책 반영합니다 ~!

> 구현 내용 및 작업 했던 내역

- [x] 표준 섹터(11개)를 제외하고 전부 ETC로 반환하도록 수정
- [x] 섹터 상세 조회 페이지에서 배당금 정보 제거
- [x] 스케줄러 코드 리팩터링 및 성능 개선 (불필요한 조회 로직 제거)
- [x] 배당금 관련 계산 로직 도메인 서비스로 이동

### 변경사항

- 의존성 목록

### PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1
- 특이 사항 2
