### PR TITLE
feat: implement stockSearch API

### DIFF
--- a/api-server/src/main/java/nexters/payout/apiserver/stock/application/StockQueryService.java
+++ b/api-server/src/main/java/nexters/payout/apiserver/stock/application/StockQueryService.java
@@ -5,6 +5,7 @@ import nexters.payout.apiserver.stock.application.dto.request.SectorRatioRequest
 import nexters.payout.apiserver.stock.application.dto.request.TickerShare;
 import nexters.payout.apiserver.stock.application.dto.response.SectorRatioResponse;
 import nexters.payout.apiserver.stock.application.dto.response.StockDetailResponse;
+import nexters.payout.apiserver.stock.application.dto.response.StockResponse;
 import nexters.payout.core.exception.error.NotFoundException;
 import nexters.payout.core.time.InstantProvider;
 import nexters.payout.domain.dividend.domain.Dividend;
@@ -12,6 +13,7 @@ import nexters.payout.domain.dividend.domain.repository.DividendRepository;
 import nexters.payout.domain.stock.domain.Sector;
 import nexters.payout.domain.stock.domain.Stock;
 import nexters.payout.domain.stock.domain.repository.StockRepository;
+import nexters.payout.domain.stock.domain.repository.StockRepositoryCustom;
 import nexters.payout.domain.stock.domain.service.DividendAnalysisService;
 import nexters.payout.domain.stock.domain.service.SectorAnalysisService;
 import nexters.payout.domain.stock.domain.service.SectorAnalysisService.SectorInfo;
@@ -30,9 +32,17 @@ import java.util.stream.Collectors;
 public class StockQueryService {
 
     private final StockRepository stockRepository;
+    private final StockRepositoryCustom stockRepositoryCustom;
     private final DividendRepository dividendRepository;
     private final SectorAnalysisService sectorAnalysisService;
     private final DividendAnalysisService dividendAnalysisService;
+
+    public List<StockResponse> searchStock(final String keyword) {
+        return stockRepositoryCustom.findStocksByTickerOrNameWithPriority(keyword)
+                .stream()
+                .map(StockResponse::from)
+                .collect(Collectors.toList());
+    }
 
     public StockDetailResponse getStockByTicker(final String ticker) {
         Stock stock = stockRepository.findByTicker(ticker)

--- a/api-server/src/main/java/nexters/payout/apiserver/stock/application/dto/response/StockResponse.java
+++ b/api-server/src/main/java/nexters/payout/apiserver/stock/application/dto/response/StockResponse.java
@@ -1,6 +1,5 @@
 package nexters.payout.apiserver.stock.application.dto.response;
 
-import nexters.payout.domain.dividend.domain.Dividend;
 import nexters.payout.domain.stock.domain.Stock;
 
 import java.util.UUID;

--- a/api-server/src/main/java/nexters/payout/apiserver/stock/presentation/StockController.java
+++ b/api-server/src/main/java/nexters/payout/apiserver/stock/presentation/StockController.java
@@ -7,11 +7,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.RequiredArgsConstructor;
 import nexters.payout.apiserver.stock.application.StockQueryService;
 import nexters.payout.apiserver.stock.application.dto.request.SectorRatioRequest;
 import nexters.payout.apiserver.stock.application.dto.response.SectorRatioResponse;
 import nexters.payout.apiserver.stock.application.dto.response.StockDetailResponse;
+import nexters.payout.apiserver.stock.application.dto.response.StockResponse;
 import nexters.payout.core.exception.ErrorResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -25,10 +27,16 @@ public class StockController implements StockControllerDocs {
 
     private final StockQueryService stockQueryService;
 
+    @GetMapping("/search")
+    public ResponseEntity<List<StockResponse>> searchStock(
+            @RequestParam @NotEmpty final String keyword
+    ) {
+        return ResponseEntity.ok(stockQueryService.searchStock(keyword));
+    }
+
     @GetMapping("/{ticker}")
     public ResponseEntity<StockDetailResponse> getStockByTicker(
-            @Parameter(description = "ticker name of stock", example = "AAPL")
-            @PathVariable String ticker
+            @PathVariable final String ticker
     ) {
         return ResponseEntity.ok(stockQueryService.getStockByTicker(ticker));
     }

--- a/api-server/src/main/java/nexters/payout/apiserver/stock/presentation/StockControllerDocs.java
+++ b/api-server/src/main/java/nexters/payout/apiserver/stock/presentation/StockControllerDocs.java
@@ -23,6 +23,13 @@ import java.util.List;
 
 public interface StockControllerDocs {
 
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "SUCCESS"),
+            @ApiResponse(responseCode = "400", description = "BAD REQUEST",
+                    content = {@Content(schema = @Schema(implementation = ErrorResponse.class))}),
+            @ApiResponse(responseCode = "500", description = "SERVER ERROR",
+                    content = {@Content(schema = @Schema(implementation = ErrorResponse.class))})
+    })
     @Operation(summary = "티커명/회사명 검색")
     ResponseEntity<List<StockResponse>> searchStock(
             @Parameter(description = "tickerName or companyName of stock ex) APPL, APPLE")

--- a/api-server/src/main/java/nexters/payout/apiserver/stock/presentation/StockControllerDocs.java
+++ b/api-server/src/main/java/nexters/payout/apiserver/stock/presentation/StockControllerDocs.java
@@ -8,17 +8,26 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
 import nexters.payout.apiserver.stock.application.dto.request.SectorRatioRequest;
 import nexters.payout.apiserver.stock.application.dto.response.SectorRatioResponse;
 import nexters.payout.apiserver.stock.application.dto.response.StockDetailResponse;
+import nexters.payout.apiserver.stock.application.dto.response.StockResponse;
 import nexters.payout.core.exception.ErrorResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
 public interface StockControllerDocs {
+
+    @Operation(summary = "티커명/회사명 검색")
+    ResponseEntity<List<StockResponse>> searchStock(
+            @Parameter(description = "tickerName or companyName of stock ex) APPL, APPLE")
+            @RequestParam @NotEmpty String ticker
+    );
 
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "SUCCESS"),
@@ -31,7 +40,7 @@ public interface StockControllerDocs {
     })
     @Operation(summary = "종목 상세 조회")
     ResponseEntity<StockDetailResponse> getStockByTicker(
-            @Parameter(description = "ticker name of stock", example = "AAPL")
+            @Parameter(description = "tickerName of stock", example = "AAPL")
             @PathVariable String ticker
     );
 

--- a/api-server/src/test/java/nexters/payout/apiserver/stock/application/StockQueryServiceTest.java
+++ b/api-server/src/test/java/nexters/payout/apiserver/stock/application/StockQueryServiceTest.java
@@ -12,6 +12,7 @@ import nexters.payout.domain.dividend.domain.repository.DividendRepository;
 import nexters.payout.domain.stock.domain.Sector;
 import nexters.payout.domain.stock.domain.Stock;
 import nexters.payout.domain.stock.domain.repository.StockRepository;
+import nexters.payout.domain.stock.domain.repository.StockRepositoryCustom;
 import nexters.payout.domain.stock.domain.service.DividendAnalysisService;
 import nexters.payout.domain.stock.domain.service.SectorAnalysisService;
 import org.junit.jupiter.api.Test;
@@ -44,11 +45,29 @@ class StockQueryServiceTest {
     @Mock
     private StockRepository stockRepository;
     @Mock
+    private StockRepositoryCustom stockRepositoryCustom;
+    @Mock
     private DividendRepository dividendRepository;
     @Spy
     private SectorAnalysisService sectorAnalysisService;
     @Spy
     private DividendAnalysisService dividendAnalysisService;
+
+    @Test
+    void 검색된_종목_정보를_정상적으로_반환한다() {
+        // given
+        given(stockRepositoryCustom.findStocksByTickerOrNameWithPriority(any())).willReturn(List.of(StockFixture.createStock(AAPL, Sector.TECHNOLOGY)));
+
+        // when
+        List<StockResponse> actual = stockQueryService.searchStock("A");
+
+        // then
+        assertAll(
+                () -> assertThat(actual.get(0).ticker()).isEqualTo(AAPL),
+                () -> assertThat(actual.get(0).sectorName()).isEqualTo(Sector.TECHNOLOGY.getName())
+        );
+
+    }
 
     @Test
     void 종목_상세_정보를_정상적으로_반환한다() {

--- a/batch/src/main/java/nexters/payout/batch/PayoutBatchApplication.java
+++ b/batch/src/main/java/nexters/payout/batch/PayoutBatchApplication.java
@@ -5,7 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-
 @ConfigurationPropertiesScan
 @SpringBootApplication(scanBasePackages = {
         "nexters.payout.core",

--- a/batch/src/main/java/nexters/payout/batch/application/FinancialClient.java
+++ b/batch/src/main/java/nexters/payout/batch/application/FinancialClient.java
@@ -23,7 +23,11 @@ public interface FinancialClient {
             Integer avgVolume
     ) {
         Stock toDomain() {
-            return new Stock(ticker, name, sector, exchange, industry, price, volume);
+            return new Stock(ticker, name, sector, exchange, industry, price, volume, null);
+        }
+
+        Stock toDomain(String logoUrl) {
+            return new Stock(ticker, name, sector, exchange, industry, price, volume, logoUrl);
         }
     }
 

--- a/batch/src/main/java/nexters/payout/batch/application/StockLogo.java
+++ b/batch/src/main/java/nexters/payout/batch/application/StockLogo.java
@@ -1,0 +1,5 @@
+package nexters.payout.batch.application;
+
+public interface StockLogo {
+    String getLogoUrl(String ticker);
+}

--- a/batch/src/main/java/nexters/payout/batch/infra/ninjas/NinjasDto.java
+++ b/batch/src/main/java/nexters/payout/batch/infra/ninjas/NinjasDto.java
@@ -1,0 +1,9 @@
+package nexters.payout.batch.infra.ninjas;
+
+record NinjasStockLogo(
+        String name,
+        String ticker,
+        String image
+) {
+
+}

--- a/batch/src/main/java/nexters/payout/batch/infra/ninjas/NinjasFinancialClient.java
+++ b/batch/src/main/java/nexters/payout/batch/infra/ninjas/NinjasFinancialClient.java
@@ -1,0 +1,42 @@
+package nexters.payout.batch.infra.ninjas;
+
+import lombok.extern.slf4j.Slf4j;
+import nexters.payout.batch.application.StockLogo;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+@Slf4j
+public class NinjasFinancialClient implements StockLogo {
+
+    private final WebClient ninjasWebClient;
+    private final NinjasProperties ninjasProperties;
+
+    NinjasFinancialClient(final NinjasProperties ninjasProperties) {
+        this.ninjasProperties = ninjasProperties;
+        this.ninjasWebClient = WebClient.builder()
+                .baseUrl(ninjasProperties.getBaseUrl())
+                .defaultHeader("X-Api-Key", ninjasProperties.getApiKey())
+                .build();
+    }
+
+    @Override
+    public String getLogoUrl(String ticker) {
+        return fetchLogoUrl(ticker).image();
+    }
+
+    private NinjasStockLogo fetchLogoUrl(String ticker) {
+        return ninjasWebClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path(ninjasProperties.getLogoPath())
+                        .queryParam("ticker", ticker)
+                        .build())
+                .retrieve()
+                .bodyToFlux(NinjasStockLogo.class)
+                .next()
+                .doOnError(e -> log.error("fetchLogoUrl 호출 실패: {}", e.getMessage()))
+                .onErrorReturn(new NinjasStockLogo(ticker, ticker, null))
+                .blockOptional()
+                .orElse(new NinjasStockLogo(ticker, ticker, null));
+    }
+}

--- a/batch/src/main/java/nexters/payout/batch/infra/ninjas/NinjasProperties.java
+++ b/batch/src/main/java/nexters/payout/batch/infra/ninjas/NinjasProperties.java
@@ -1,0 +1,14 @@
+package nexters.payout.batch.infra.ninjas;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("financial.ninjas")
+@RequiredArgsConstructor
+@Getter
+public class NinjasProperties {
+    final String apiKey;
+    final String baseUrl;
+    final String logoPath;
+}

--- a/batch/src/main/resources/application-dev.yml
+++ b/batch/src/main/resources/application-dev.yml
@@ -28,6 +28,6 @@ financial:
 schedules:
   cron:
     dividend: 0 0 0 * * *
-    stock: 0 0/10 * * * *
+    stock: 0 0 1 * * * *
     
 

--- a/batch/src/main/resources/application-dev.yml
+++ b/batch/src/main/resources/application-dev.yml
@@ -20,6 +20,10 @@ financial:
     exchange-symbols-stock-list-path: /api/v3/symbol/
     stock-screener-path: /api/v3/stock-screener
     stock-dividend-calender-path: /api/v3/stock_dividend_calendar
+  ninjas:
+    api-key: ${NINJAS_API_KEY}
+    base-url: https://api.api-ninjas.com
+    logo-path: /v1/logo
 
 schedules:
   cron:

--- a/batch/src/main/resources/application-prod.yml
+++ b/batch/src/main/resources/application-prod.yml
@@ -24,8 +24,8 @@ spring:
 
 schedules:
   cron:
-    stock: "0 0 0 * * *"
-    dividend: "0 0 1 * * *"
+    stock: "0 0 3 * * *"
+    dividend: "0 0 4 * * *"
 
 financial:
   fmp:

--- a/batch/src/main/resources/application-prod.yml
+++ b/batch/src/main/resources/application-prod.yml
@@ -34,4 +34,8 @@ financial:
     stock-list-path: /api/v3/stock/list
     exchange-symbols-stock-list-path: /api/v3/symbol/
     stock-screener-path: /api/v3/stock-screener
-    stock-dividend-calender-path: "/api/v3/stock_dividend_calendar"
+    stock-dividend-calender-path: /api/v3/stock_dividend_calendar
+  ninjas:
+    api-key: ${NINJAS_API_KEY}
+    base-url: https://api.api-ninjas.com
+    logo-path: /v1/logo

--- a/domain/src/main/java/nexters/payout/domain/stock/application/StockCommandService.java
+++ b/domain/src/main/java/nexters/payout/domain/stock/application/StockCommandService.java
@@ -13,6 +13,17 @@ public class StockCommandService {
 
     private final StockRepository stockRepository;
 
+    public void create(Stock stockData) {
+        stockRepository.save(stockData);
+    }
+
+    public void update(String ticker, Stock stockData) {
+        stockRepository.findByTicker(ticker)
+                .ifPresent(
+                        existing -> existing.update(stockData.getPrice(), stockData.getVolume())
+                );
+    }
+
     public void saveOrUpdate(String ticker, Stock stockData) {
         stockRepository.findByTicker(ticker)
                 .ifPresentOrElse(

--- a/domain/src/main/java/nexters/payout/domain/stock/domain/Sector.java
+++ b/domain/src/main/java/nexters/payout/domain/stock/domain/Sector.java
@@ -34,7 +34,8 @@ public enum Sector {
         this.name = name;
     }
 
-    private static final Map<String, Sector> NAME_TO_SECTOR_MAP = Arrays.stream(values())
+    private static final Map<String, Sector> NAME_TO_SECTOR_MAP = Arrays
+            .stream(values())
             .collect(Collectors.toMap(sector -> sector.name, Function.identity()));
 
     private static final Set<String> ETC_NAMES = Set.of(FINANCIAL.name, SERVICES.name, CONGLOMERATES.name);
@@ -46,12 +47,12 @@ public enum Sector {
                 .toList();
     }
 
-    public static Sector fromValue(String value) {
-        if (isEtcCategory(value)) {
+    public static Sector fromValue(String sectorName) {
+        if (isEtcCategory(sectorName)) {
             return ETC;
         }
 
-        return NAME_TO_SECTOR_MAP.getOrDefault(value.toUpperCase(), ETC);
+        return NAME_TO_SECTOR_MAP.getOrDefault(sectorName, ETC);
     }
 
     private static boolean isEtcCategory(String value) {

--- a/domain/src/main/java/nexters/payout/domain/stock/domain/Stock.java
+++ b/domain/src/main/java/nexters/payout/domain/stock/domain/Stock.java
@@ -35,9 +35,11 @@ public class Stock extends BaseEntity {
 
     private Integer volume;
 
+    private String logoUrl;
+
     public Stock(final UUID id, final String ticker, final String name,
                  final Sector sector, final String exchange, final String industry,
-                 final Double price, final Integer volume) {
+                 final Double price, final Integer volume, final String logoUrl) {
         validateTicker(ticker);
         this.id = id;
         this.ticker = ticker;
@@ -47,12 +49,13 @@ public class Stock extends BaseEntity {
         this.industry = industry;
         this.price = price;
         this.volume = volume;
+        this.logoUrl = logoUrl;
     }
 
     public Stock(final String ticker, final String name,
                  final Sector sector, final String exchange, final String industry,
-                 final Double price, final Integer volume) {
-        this(null, ticker, name, sector, exchange, industry, price, volume);
+                 final Double price, final Integer volume, final String logoUrl) {
+        this(null, ticker, name, sector, exchange, industry, price, volume, logoUrl);
     }
 
     private void validateTicker(final String ticker) {

--- a/domain/src/main/java/nexters/payout/domain/stock/domain/repository/StockRepositoryCustom.java
+++ b/domain/src/main/java/nexters/payout/domain/stock/domain/repository/StockRepositoryCustom.java
@@ -1,0 +1,13 @@
+package nexters.payout.domain.stock.domain.repository;
+
+import nexters.payout.domain.stock.domain.Stock;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface StockRepositoryCustom {
+
+    List<Stock> findStocksByTickerOrNameWithPriority(String search);
+
+}

--- a/domain/src/main/java/nexters/payout/domain/stock/domain/repository/StockRepositoryImpl.java
+++ b/domain/src/main/java/nexters/payout/domain/stock/domain/repository/StockRepositoryImpl.java
@@ -1,0 +1,40 @@
+package nexters.payout.domain.stock.domain.repository;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import nexters.payout.domain.stock.domain.QStock;
+import nexters.payout.domain.stock.domain.Stock;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class StockRepositoryImpl implements StockRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Stock> findStocksByTickerOrNameWithPriority(String keyword) {
+        QStock stock = QStock.stock;
+
+        // 검색 조건
+        BooleanExpression tickerStartsWith = stock.ticker.startsWith(keyword);
+        BooleanExpression nameContains = stock.name.contains(keyword);
+
+        // 정렬 조건
+        OrderSpecifier<Integer> orderByPriority = new CaseBuilder()
+                .when(tickerStartsWith).then(1)
+                .when(nameContains).then(2)
+                .otherwise(3)
+                .asc();
+        OrderSpecifier<String> orderByTicker = stock.ticker.asc();
+        OrderSpecifier<String> orderByName = stock.name.asc();
+
+        return queryFactory.selectFrom(stock)
+                .where(tickerStartsWith.or(nameContains))
+                .orderBy(orderByPriority, orderByTicker, orderByName)
+                .fetch();
+    }
+}

--- a/domain/src/testFixtures/java/nexters/payout/domain/StockFixture.java
+++ b/domain/src/testFixtures/java/nexters/payout/domain/StockFixture.java
@@ -12,18 +12,18 @@ public class StockFixture {
     public static final String SBUX = "SBUX";
 
     public static Stock createStock(String ticker, Double price, Integer volume) {
-        return new Stock(ticker, "tesla", Sector.FINANCIAL_SERVICES, Exchange.NYSE.name(), "industry", price, volume);
+        return new Stock(ticker, "tesla", Sector.FINANCIAL_SERVICES, Exchange.NYSE.name(), "industry", price, volume, "");
     }
 
     public static Stock createStock(String ticker, Sector sector) {
-        return new Stock(UUID.randomUUID(), ticker, ticker, sector, Exchange.NYSE.name(), "industry", 0.0, 0);
+        return new Stock(UUID.randomUUID(), ticker, ticker, sector, Exchange.NYSE.name(), "industry", 0.0, 0, "");
     }
 
     public static Stock createStock(String ticker, String companyName) {
-        return new Stock(UUID.randomUUID(), ticker, companyName, Sector.TECHNOLOGY, Exchange.NYSE.name(), "industry", 0.0, 0);
+        return new Stock(UUID.randomUUID(), ticker, companyName, Sector.TECHNOLOGY, Exchange.NYSE.name(), "industry", 0.0, 0, "");
     }
 
     public static Stock createStock(String ticker, Sector sector, Double price) {
-        return new Stock(UUID.randomUUID(), ticker, ticker, sector, Exchange.NYSE.name(), "industry", price, 0);
+        return new Stock(UUID.randomUUID(), ticker, ticker, sector, Exchange.NYSE.name(), "industry", price, 0, "");
     }
 }

--- a/domain/src/testFixtures/java/nexters/payout/domain/StockFixture.java
+++ b/domain/src/testFixtures/java/nexters/payout/domain/StockFixture.java
@@ -19,6 +19,10 @@ public class StockFixture {
         return new Stock(UUID.randomUUID(), ticker, ticker, sector, Exchange.NYSE.name(), "industry", 0.0, 0);
     }
 
+    public static Stock createStock(String ticker, String companyName) {
+        return new Stock(UUID.randomUUID(), ticker, companyName, Sector.TECHNOLOGY, Exchange.NYSE.name(), "industry", 0.0, 0);
+    }
+
     public static Stock createStock(String ticker, Sector sector, Double price) {
         return new Stock(UUID.randomUUID(), ticker, ticker, sector, Exchange.NYSE.name(), "industry", price, 0);
     }


### PR DESCRIPTION
### Issue Number

close: #33 

### 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 티커명, 회사명 검색 API 구현
- [x] 테스트코드 작성

### 변경사항

- 의존성 목록

### 논의하고 싶은 사항
- 저희 기존에 쓰려고 했던 로고 조회하는 eodhd API가 생각보다 많은 티커가 지원되지 않더라구요ㅠㅠ (예를 들면 AAPL,META, GOOGL..)  
   이전에 민호님께서 찾으신 [ninja](https://api-ninjas.com/api/logo) API 사용하고 스케줄링할 때 같이 DB에 저장해놓고 사용하는 방법으로 바꾸는 건 어떨까 합니다 (유명한 티커 로고가 안보이는건 조금 크리티컬하지 않나 싶어서요!)
그래서 일단 로고 URL 은 구현에 포함하지 않았고 민호님과 이야기 후 구현 예정입니닷


### PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 쿼리가 정렬 우선순위 정책으로 인해 조금 복잡해서 queryDSL 사용했는데 queryDSL을 많이 써보지는 않아서 혹시 더 좋은 코드가 있다면 알려주세요!

