### PR TITLE
fix: fix scheduler cycle and logging option

### DIFF
--- a/batch/src/main/java/nexters/payout/batch/application/DividendBatchService.java
+++ b/batch/src/main/java/nexters/payout/batch/application/DividendBatchService.java
@@ -6,15 +6,12 @@ import lombok.extern.slf4j.Slf4j;
 import nexters.payout.batch.application.FinancialClient.DividendData;
 import nexters.payout.domain.dividend.domain.Dividend;
 import nexters.payout.domain.dividend.application.DividendCommandService;
-import nexters.payout.domain.dividend.application.dto.UpdateDividendRequest;
-import nexters.payout.domain.dividend.domain.repository.DividendRepository;
 import nexters.payout.domain.stock.domain.Stock;
 import nexters.payout.domain.stock.domain.repository.StockRepository;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.UUID;
 
 /**
  * 배당금 관련 스케쥴러 서비스 클래스입니다.

--- a/batch/src/main/java/nexters/payout/batch/infra/fmp/FmpFinancialClient.java
+++ b/batch/src/main/java/nexters/payout/batch/infra/fmp/FmpFinancialClient.java
@@ -2,6 +2,7 @@ package nexters.payout.batch.infra.fmp;
 
 import lombok.extern.slf4j.Slf4j;
 import nexters.payout.batch.application.FinancialClient;
+import nexters.payout.core.time.InstantProvider;
 import nexters.payout.domain.stock.domain.Exchange;
 import nexters.payout.domain.stock.domain.Sector;
 import org.springframework.stereotype.Service;
@@ -10,10 +11,11 @@ import reactor.core.publisher.Mono;
 
 import java.text.SimpleDateFormat;
 import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.LocalDate;
 import java.util.*;
 import java.util.stream.Collectors;
+
+import static java.time.ZoneOffset.UTC;
 
 @Slf4j
 @Service
@@ -96,12 +98,16 @@ public class FmpFinancialClient implements FinancialClient {
     @Override
     public List<DividendData> getDividendList() {
 
-        // TODO (작년 1월 ~ 12월 데이터 고정적으로 가져오도록 수정 필요)
-        // 3개월 간 총 4번의 데이터를 조회함으로써 기준 날짜로부터 이전 1년 간의 데이터를 조회
+        // 현재 시간을 기준으로 작년 1월 ~ 12월의 배당금 데이터를 조회
         List<DividendData> result = new ArrayList<>();
-        for (int i = 0; i < 4; i++) {
+        for (int month = 1; month <= 10; month += 3) {
 
-            Instant date = ZonedDateTime.now(ZoneOffset.UTC).minusDays(1).minusMonths(i).toInstant();
+            Instant date = LocalDate.of(
+                    InstantProvider.getLastYear(),
+                    month,
+                    1)
+                    .atStartOfDay()
+                    .toInstant(UTC);
 
             List<DividendData> dividendResponses = fetchDividendList(date)
                     .stream()

--- a/batch/src/main/resources/application-prod.yml
+++ b/batch/src/main/resources/application-prod.yml
@@ -12,7 +12,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
-    show-sql: true
+    show-sql: false
 
   flyway:
     enabled: true


### PR DESCRIPTION
### Issue Number

close: #26 

### 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 배당금 스케쥴러가 작년 1월 ~ 12월의 데이터를 가져오도록 수정
- [x] batch 애플리케이션의 show-sql 옵션 해제

### 변경사항

- 의존성 목록

### PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- batch 애플리케이션 로그를 봤는데 하루만에 수백메가가 되더라구요....!! 그래서 show-sql 옵션을 해제했습니다
