### PR TITLE
fix: fix get highest dividend yield api

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - develop
-      - feat/#61
+      - feat/#63
 
 jobs:
   build-and-push:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - develop
-      - feat/#63
 
 jobs:
   build-and-push:

--- a/api-server/src/test/java/nexters/payout/apiserver/stock/presentation/integration/StockControllerTest.java
+++ b/api-server/src/test/java/nexters/payout/apiserver/stock/presentation/integration/StockControllerTest.java
@@ -427,7 +427,7 @@ class StockControllerTest extends IntegrationTest {
         ));
 
         Double expectedAaplDividendYield = 1.0;
-        Double expectedTslaDividendYield = 2.0;
+        Double expectedTslaDividendYield = 0.5;
 
         // when
         List<StockDividendYieldResponse> actual = RestAssured
@@ -444,9 +444,9 @@ class StockControllerTest extends IntegrationTest {
         // then
         assertAll(
                 () -> assertThat(actual.size()).isEqualTo(2),
-                () -> assertThat(actual.get(0).dividendYield()).isEqualTo(expectedTslaDividendYield),
-                () -> assertThat(actual.get(0).ticker()).isEqualTo(tsla.getTicker()),
-                () -> assertThat(actual.get(1).dividendYield()).isEqualTo(expectedAaplDividendYield)
+                () -> assertThat(actual.get(0).dividendYield()).isEqualTo(expectedAaplDividendYield),
+                () -> assertThat(actual.get(0).ticker()).isEqualTo(aapl.getTicker()),
+                () -> assertThat(actual.get(1).dividendYield()).isEqualTo(expectedTslaDividendYield)
         );
     }
 

--- a/domain/src/main/java/nexters/payout/domain/stock/infra/StockRepositoryImpl.java
+++ b/domain/src/main/java/nexters/payout/domain/stock/infra/StockRepositoryImpl.java
@@ -70,12 +70,12 @@ public class StockRepositoryImpl implements StockRepositoryCustom {
     @Override
     public List<StockDividendYieldDto> findBiggestDividendYieldStock(int lastYear, int pageNumber, int pageSize) {
 
-        NumberExpression<Double> dividendYield = stock.price.divide(dividend1.dividend.sum().coalesce(0.0));
+        NumberExpression<Double> dividendYield = dividend1.dividend.sum().coalesce(1.0).divide(stock.price);
 
         return queryFactory
                 .select(Projections.constructor(StockDividendYieldDto.class, stock, dividendYield))
                 .from(stock)
-                .leftJoin(dividend1)
+                .innerJoin(dividend1)
                 .on(stock.id.eq(dividend1.stockId))
                 .where(dividend1.exDividendDate.year().eq(lastYear))
                 .groupBy(stock.id, stock.price)

--- a/domain/src/test/java/nexters/payout/domain/stock/service/DividendAnalysisServiceTest.java
+++ b/domain/src/test/java/nexters/payout/domain/stock/service/DividendAnalysisServiceTest.java
@@ -80,15 +80,13 @@ class DividendAnalysisServiceTest {
 
         Dividend pastDividend = DividendFixture.createDividend(
                 UUID.randomUUID(),
-                LocalDate.of(now.getYear() - 1, now.getMonth(), now.getDayOfMonth() - 3)
+                LocalDate.of(now.getYear() - 1, 1, 10)
                         .atStartOfDay(ZoneId.systemDefault()).toInstant()
         );
 
-        int plusDay = Math.max(now.getDayOfMonth(), now.plusDays(3).getDayOfMonth());
-
         Dividend earlistDividend = DividendFixture.createDividend(
                 UUID.randomUUID(),
-                LocalDate.of(now.getYear() - 1, now.getMonth(), plusDay)
+                LocalDate.of(now.getYear() - 1, 3, 10)
                         .atStartOfDay(ZoneId.systemDefault()).toInstant()
         );
         List<Dividend> lastYearDividends = List.of(pastDividend, earlistDividend);
@@ -109,7 +107,7 @@ class DividendAnalysisServiceTest {
 
         Dividend lastYearDividend = DividendFixture.createDividend(
                 UUID.randomUUID(),
-                LocalDate.of(now.getYear() - 1, now.getMonth(), plusDay)
+                LocalDate.now().plusDays(10)
                         .atStartOfDay(ZoneId.systemDefault()).toInstant()
         );
 


### PR DESCRIPTION
### Issue Number

close: #63 

### 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] 배당수익률 계산 쿼리 수정


### 변경사항

- 의존성 목록

### PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- CD trigger 시키는데 Dividend Analysis Service test의 공시된_현재_배당금_지급일이_없는_경우_과거데이터를_기반으로_가까운_지급일을_계산한다 테스트와 공시된_현재_배당금_지급일이_존재하는_경우_실제_지급일을_반환한다 테스트에서 오류가 발생하더라구요!! 보니까 지금이 2월 26일인데 plusday가 3으로 들어가서 2024년 2월 29일을 가지고 있었는데, 여기서 연도만 2023년으로 바꾸니까 2023년 2월 29일 (2023년은 윤년이 아닌 해)가 되어서 invalid한 date여서 오류가 발생하더라구요 ㅋㅋㅋㅋㅋㅋ 신박한 오류였습니다
- 그래서 일단 월일을 하드코딩하는 방식으로 변경했어요!



- 배당수익률을 테스트하다가 종목 상세 조회 api에서 버그가 발생한 걸 알아냈습니다
1. 배당수익률을 계산하는 로직 중에 NullPointerException이 발생하길래 코드를 뜯어봤는데 dividend의 paymentDate를 비교하여 작년의 배당금 정보를 가져오더라구요! 근데 paymentDate는 null이 될 수 있는 값이라서 여기서 null인 paymentDate에 대해 오류가 발생하고 있던 것이었습니다..!!
2. (그런 이유 + 현재 dividendYield를 계산하는 로직에서 ex-dividend-date를 기준으로 작년 배당금 정보를 계산)로 인해 작년 배당금 정보를 ex-dividend-date를 기반으로 계산하는게 어떨까 해요!!
3. 일단 관련 issue를 만들어 놓을게요!
<img width="823" alt="스크린샷 2024-02-26 오후 1 37 12" src="https://github.com/Nexters/payout-server/assets/66549638/9c88829b-e5d7-43f9-8934-44a4420690cc">

