### PR TITLE
refactor: refactor code & add edge case features

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - develop
-      - refactor/#71
 
 jobs:
   build-and-push:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - develop
+      - refactor/#71
 
 jobs:
   build-and-push:

--- a/api-server/src/main/java/nexters/payout/apiserver/dividend/application/DividendQueryService.java
+++ b/api-server/src/main/java/nexters/payout/apiserver/dividend/application/DividendQueryService.java
@@ -3,6 +3,7 @@ package nexters.payout.apiserver.dividend.application;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import nexters.payout.apiserver.dividend.application.dto.request.DividendRequest;
+import nexters.payout.apiserver.dividend.application.dto.request.TickerShare;
 import nexters.payout.apiserver.dividend.application.dto.response.SingleMonthlyDividendResponse;
 import nexters.payout.apiserver.dividend.application.dto.response.MonthlyDividendResponse;
 import nexters.payout.apiserver.dividend.application.dto.response.SingleYearlyDividendResponse;
@@ -11,6 +12,7 @@ import nexters.payout.core.exception.error.NotFoundException;
 import nexters.payout.core.time.InstantProvider;
 import nexters.payout.domain.dividend.domain.Dividend;
 import nexters.payout.domain.dividend.domain.repository.DividendRepository;
+import nexters.payout.domain.stock.domain.Stock;
 import nexters.payout.domain.stock.domain.repository.StockRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +21,7 @@ import java.time.Month;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -30,30 +33,21 @@ public class DividendQueryService {
     private final StockRepository stockRepository;
 
     public List<MonthlyDividendResponse> getMonthlyDividends(final DividendRequest request) {
-
         return IntStream.rangeClosed(Month.JANUARY.getValue(), Month.DECEMBER.getValue())
                 .mapToObj(month -> MonthlyDividendResponse.of(
-                        InstantProvider.getNextYear(),
-                        month,
-                        getDividendsOfLastYearAndMonth(request, month)))
+                                InstantProvider.getNextYear(), month, getDividendsOfLastYearAndMonth(request, month)
+                        )
+                )
                 .collect(Collectors.toList());
     }
 
     public YearlyDividendResponse getYearlyDividends(final DividendRequest request) {
-
         List<SingleYearlyDividendResponse> dividends = request.tickerShares()
                 .stream()
                 .map(tickerShare -> {
                     String ticker = tickerShare.ticker();
-                    List<Dividend> findDividends = dividendRepository.findAllByTickerAndYear(ticker, InstantProvider.getLastYear());
                     return SingleYearlyDividendResponse.of(
-                            stockRepository.findByTicker(ticker)
-                                    .orElseThrow(() -> new NotFoundException(String.format("not found ticker [%s]", tickerShare.ticker()))),
-                            tickerShare.share(),
-                            findDividends
-                                    .stream()
-                                    .mapToDouble(Dividend::getDividend)
-                                    .sum()
+                            getStock(ticker), tickerShare.share(), getYearlyDividend(ticker)
                     );
                 })
                 .filter(response -> response.totalDividend() != 0)
@@ -62,26 +56,43 @@ public class DividendQueryService {
         return YearlyDividendResponse.of(dividends);
     }
 
-    private List<SingleMonthlyDividendResponse> getDividendsOfLastYearAndMonth(final DividendRequest request, int month) {
+    private double getYearlyDividend(final String ticker) {
+        return getLastYearDividendsByTicker(ticker)
+                .stream()
+                .mapToDouble(Dividend::getDividend)
+                .sum();
+    }
+
+    private List<Dividend> getLastYearDividendsByTicker(final String ticker) {
+        return dividendRepository.findAllByTickerAndYear(ticker, InstantProvider.getLastYear());
+    }
+
+    private Stock getStock(final String ticker) {
+        return stockRepository.findByTicker(ticker)
+                .orElseThrow(() -> new NotFoundException(String.format("not found ticker [%s]", ticker)));
+    }
+
+    private List<SingleMonthlyDividendResponse> getDividendsOfLastYearAndMonth(
+            final DividendRequest request, final int month
+    ) {
 
         return request.tickerShares()
                 .stream()
-                .flatMap(tickerShare -> {
-                    List<Dividend> findDividends
-                            = dividendRepository.findAllByTickerAndYearAndMonth(
-                            tickerShare.ticker(),
-                            InstantProvider.getLastYear(),
-                            month);
-
-                    return stockRepository.findByTicker(tickerShare.ticker())
-                            .map(stock -> findDividends
-                                    .stream()
-                                    .map(dividend -> SingleMonthlyDividendResponse.of(
-                                            stock,
-                                            tickerShare.share(),
-                                            dividend)))
-                            .orElseThrow(() -> new NotFoundException(String.format("not found ticker [%s]", tickerShare.ticker())));
-                })
+                .flatMap(tickerShare -> stockRepository.findByTicker(tickerShare.ticker())
+                        .map(stock -> getMonthlyDividendResponse(month, tickerShare, stock))
+                        .orElseThrow(() -> new NotFoundException(String.format("not found ticker [%s]", tickerShare.ticker()))))
                 .toList();
+    }
+
+    private Stream<SingleMonthlyDividendResponse> getMonthlyDividendResponse(
+            final int month, final TickerShare tickerShare, final Stock stock
+    ) {
+        return getLastYearDividendsByTickerAndMonth(tickerShare.ticker(), month)
+                .stream()
+                .map(dividend -> SingleMonthlyDividendResponse.of(stock, tickerShare.share(), dividend));
+    }
+
+    private List<Dividend> getLastYearDividendsByTickerAndMonth(final String ticker, final int month) {
+        return dividendRepository.findAllByTickerAndYearAndMonth(ticker, InstantProvider.getLastYear(), month);
     }
 }

--- a/api-server/src/main/java/nexters/payout/apiserver/dividend/application/DividendQueryService.java
+++ b/api-server/src/main/java/nexters/payout/apiserver/dividend/application/DividendQueryService.java
@@ -19,7 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 @Service
@@ -32,7 +31,7 @@ public class DividendQueryService {
     private final StockRepository stockRepository;
 
     public List<MonthlyDividendResponse> getMonthlyDividends(final DividendRequest request) {
-        return InstantProvider.getNext12MonthsYearMonth()
+        return InstantProvider.generateNext12Months()
                 .stream()
                 .map(yearMonth -> MonthlyDividendResponse.of(
                                 yearMonth.getYear(),

--- a/api-server/src/main/java/nexters/payout/apiserver/dividend/application/dto/response/MonthlyDividendResponse.java
+++ b/api-server/src/main/java/nexters/payout/apiserver/dividend/application/dto/response/MonthlyDividendResponse.java
@@ -15,18 +15,16 @@ public record MonthlyDividendResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         Double totalDividend
 ) {
-    public static MonthlyDividendResponse of(int year, int month, List<SingleMonthlyDividendResponse> dividends) {
-
-        dividends = dividends
-                .stream()
-                .sorted(Comparator.comparingDouble(SingleMonthlyDividendResponse::totalDividend).reversed())
-                .toList();
+    public static MonthlyDividendResponse of(
+            final int year, final int month, final List<SingleMonthlyDividendResponse> dividends
+    ) {
         return new MonthlyDividendResponse(
                 year,
                 month,
-                dividends,
-                dividends
-                        .stream()
+                dividends.stream()
+                        .sorted(Comparator.comparingDouble(SingleMonthlyDividendResponse::totalDividend).reversed())
+                        .toList(),
+                dividends.stream()
                         .mapToDouble(SingleMonthlyDividendResponse::totalDividend)
                         .sum()
         );

--- a/api-server/src/main/java/nexters/payout/apiserver/dividend/presentation/DividendController.java
+++ b/api-server/src/main/java/nexters/payout/apiserver/dividend/presentation/DividendController.java
@@ -24,14 +24,16 @@ public class DividendController implements DividendControllerDocs {
     private final DividendQueryService dividendQueryService;
 
     @PostMapping("/monthly")
-    public ResponseEntity<List<MonthlyDividendResponse>> getMonthlyDividends(@RequestBody @Valid final DividendRequest request) {
-
+    public ResponseEntity<List<MonthlyDividendResponse>> getMonthlyDividends(
+            @RequestBody @Valid final DividendRequest request
+    ) {
         return ResponseEntity.ok(dividendQueryService.getMonthlyDividends(request));
     }
 
     @PostMapping("/yearly")
-    public ResponseEntity<YearlyDividendResponse> getYearlyDividends(@RequestBody @Valid final DividendRequest request) {
-
+    public ResponseEntity<YearlyDividendResponse> getYearlyDividends(
+            @RequestBody @Valid final DividendRequest request
+    ) {
         return ResponseEntity.ok(dividendQueryService.getYearlyDividends(request));
     }
 }

--- a/api-server/src/main/java/nexters/payout/apiserver/stock/application/StockQueryService.java
+++ b/api-server/src/main/java/nexters/payout/apiserver/stock/application/StockQueryService.java
@@ -78,8 +78,7 @@ public class StockQueryService {
         return stockRepository.findByTicker(ticker)
                 .orElseThrow(() -> new NotFoundException(String.format("not found ticker [%s]", ticker)));
     }
-
-
+    
     private List<Dividend> getLastYearDividends(final Stock stock) {
         int lastYear = InstantProvider.getLastYear();
 

--- a/api-server/src/main/java/nexters/payout/apiserver/stock/application/StockQueryService.java
+++ b/api-server/src/main/java/nexters/payout/apiserver/stock/application/StockQueryService.java
@@ -49,6 +49,11 @@ public class StockQueryService {
         List<Month> dividendMonths = dividendAnalysisService.calculateDividendMonths(stock, lastYearDividends);
         Double dividendYield = dividendAnalysisService.calculateDividendYield(stock, lastYearDividends);
 
+        System.out.println("--테스트--");
+        dividendMonths.forEach(s -> {
+            System.out.println("month:" + s);
+        });
+        System.out.println(dividendYield);
         return dividendAnalysisService.findUpcomingDividend(lastYearDividends, thisYearDividends)
                 .map(dividend -> StockDetailResponse.of(stock, dividend, dividendMonths, dividendYield))
                 .orElseGet(() -> StockDetailResponse.from(stock));

--- a/api-server/src/main/java/nexters/payout/apiserver/stock/application/StockQueryService.java
+++ b/api-server/src/main/java/nexters/payout/apiserver/stock/application/StockQueryService.java
@@ -54,13 +54,13 @@ public class StockQueryService {
                 .orElseGet(() -> StockDetailResponse.from(stock));
     }
 
-    private Stock getStock(String ticker) {
+    private Stock getStock(final String ticker) {
         return stockRepository.findByTicker(ticker)
                 .orElseThrow(() -> new NotFoundException(String.format("not found ticker [%s]", ticker)));
     }
 
 
-    private List<Dividend> getLastYearDividends(Stock stock) {
+    private List<Dividend> getLastYearDividends(final Stock stock) {
         int lastYear = InstantProvider.getLastYear();
 
         return dividendRepository.findAllByStockId(stock.getId())
@@ -69,7 +69,7 @@ public class StockQueryService {
                 .collect(Collectors.toList());
     }
 
-    private List<Dividend> getThisYearDividends(Stock stock) {
+    private List<Dividend> getThisYearDividends(final Stock stock) {
         int thisYear = InstantProvider.getThisYear();
 
         return dividendRepository.findAllByStockId(stock.getId())
@@ -86,8 +86,7 @@ public class StockQueryService {
         return SectorRatioResponse.fromMap(sectorInfoMap);
     }
 
-    public List<UpcomingDividendResponse> getUpcomingDividendStocks(int pageNumber, int pageSize) {
-
+    public List<UpcomingDividendResponse> getUpcomingDividendStocks(final int pageNumber, final int pageSize) {
         return stockRepository.findUpcomingDividendStock(pageNumber, pageSize)
                 .stream()
                 .map(stockDividend -> UpcomingDividendResponse.of(
@@ -97,8 +96,7 @@ public class StockQueryService {
                 .collect(Collectors.toList());
     }
 
-    public List<StockDividendYieldResponse> getBiggestDividendStocks(int pageNumber, int pageSize) {
-
+    public List<StockDividendYieldResponse> getBiggestDividendStocks(final int pageNumber, final int pageSize) {
         return stockRepository.findBiggestDividendYieldStock(InstantProvider.getLastYear(), pageNumber, pageSize)
                 .stream()
                 .map(stockDividendYield -> StockDividendYieldResponse.of(

--- a/api-server/src/main/java/nexters/payout/apiserver/stock/application/dto/response/DividendResponse.java
+++ b/api-server/src/main/java/nexters/payout/apiserver/stock/application/dto/response/DividendResponse.java
@@ -1,0 +1,57 @@
+package nexters.payout.apiserver.stock.application.dto.response;
+
+import nexters.payout.core.time.InstantProvider;
+import nexters.payout.domain.dividend.domain.Dividend;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Collections;
+import java.util.List;
+
+public record DividendResponse(
+        Double dividendPerShare,
+        LocalDate exDividendDate,
+        LocalDate paymentDate,
+        Double dividendYield,
+        List<Month> dividendMonths
+) {
+
+    public static DividendResponse noDividend() {
+        return new DividendResponse(
+                0.0,
+                null,
+                null,
+                0.0,
+                Collections.emptyList()
+        );
+    }
+
+    public static DividendResponse withoutDividendDates(
+            final Double dividendPerShare,
+            final Double dividendYield,
+            final List<Month> dividendMonths
+    ) {
+        return new DividendResponse(
+                dividendPerShare,
+                null,
+                null,
+                dividendYield,
+                dividendMonths
+        );
+    }
+
+    public static DividendResponse fullDividendInfo(
+            final Dividend dividend,
+            final Double dividendYield,
+            final List<Month> dividendMonths
+    ) {
+        return new DividendResponse(
+                dividend.getDividend(),
+                InstantProvider.toLocalDate(dividend.getExDividendDate()).withYear(InstantProvider.getThisYear()),
+                dividend.getPaymentDate() == null ? null : InstantProvider.toLocalDate(dividend.getPaymentDate())
+                        .withYear(InstantProvider.getThisYear()),
+                dividendYield,
+                dividendMonths
+        );
+    }
+}

--- a/api-server/src/main/java/nexters/payout/apiserver/stock/application/dto/response/StockDetailResponse.java
+++ b/api-server/src/main/java/nexters/payout/apiserver/stock/application/dto/response/StockDetailResponse.java
@@ -7,7 +7,6 @@ import nexters.payout.domain.stock.domain.Stock;
 
 import java.time.LocalDate;
 import java.time.Month;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -42,7 +41,7 @@ public record StockDetailResponse(
         List<Month> dividendMonths
 ) {
 
-    public static StockDetailResponse from(final Stock stock) {
+    public static StockDetailResponse from(final Stock stock, final List<Month> dividendMonths, final Double dividendYield) {
         return new StockDetailResponse(
                 stock.getId(),
                 stock.getTicker(),
@@ -56,8 +55,29 @@ public record StockDetailResponse(
                 null,
                 null,
                 null,
-                null,
-                Collections.emptyList()
+                dividendYield,
+                dividendMonths
+        );
+    }
+
+    public static StockDetailResponse of(
+            final Stock stock, final DividendResponse dividendResponse
+    ) {
+        return new StockDetailResponse(
+                stock.getId(),
+                stock.getTicker(),
+                stock.getName(),
+                stock.getSector().getName(),
+                stock.getExchange(),
+                stock.getIndustry(),
+                stock.getPrice(),
+                stock.getVolume(),
+                stock.getLogoUrl(),
+                dividendResponse.dividendPerShare(),
+                dividendResponse.exDividendDate(),
+                dividendResponse.paymentDate(),
+                dividendResponse.dividendYield(),
+                dividendResponse.dividendMonths()
         );
     }
 

--- a/api-server/src/main/java/nexters/payout/apiserver/stock/application/dto/response/StockDetailResponse.java
+++ b/api-server/src/main/java/nexters/payout/apiserver/stock/application/dto/response/StockDetailResponse.java
@@ -42,7 +42,7 @@ public record StockDetailResponse(
         List<Month> dividendMonths
 ) {
 
-    public static StockDetailResponse from(Stock stock) {
+    public static StockDetailResponse from(final Stock stock) {
         return new StockDetailResponse(
                 stock.getId(),
                 stock.getTicker(),
@@ -61,7 +61,9 @@ public record StockDetailResponse(
         );
     }
 
-    public static StockDetailResponse of(Stock stock, Dividend dividend, List<Month> dividendMonths, Double dividendYield) {
+    public static StockDetailResponse of(
+            final Stock stock, final Dividend dividend, final List<Month> dividendMonths, final Double dividendYield
+    ) {
         int thisYear = InstantProvider.getThisYear();
         return new StockDetailResponse(
                 stock.getId(),

--- a/api-server/src/main/java/nexters/payout/apiserver/stock/application/dto/response/StockDividendYieldResponse.java
+++ b/api-server/src/main/java/nexters/payout/apiserver/stock/application/dto/response/StockDividendYieldResponse.java
@@ -16,7 +16,7 @@ public record StockDividendYieldResponse(
         Double dividendYield
 ) {
 
-    public static StockDividendYieldResponse of(Stock stock, Double dividendYield) {
+    public static StockDividendYieldResponse of(final Stock stock, final Double dividendYield) {
         return new StockDividendYieldResponse(
                 stock.getId(),
                 stock.getTicker(),

--- a/api-server/src/main/java/nexters/payout/apiserver/stock/application/dto/response/StockResponse.java
+++ b/api-server/src/main/java/nexters/payout/apiserver/stock/application/dto/response/StockResponse.java
@@ -25,7 +25,7 @@ public record StockResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         String logoUrl
 ) {
-    public static StockResponse from(Stock stock) {
+    public static StockResponse from(final Stock stock) {
         return new StockResponse(
                 stock.getId(),
                 stock.getTicker(),

--- a/api-server/src/main/java/nexters/payout/apiserver/stock/application/dto/response/StockShareResponse.java
+++ b/api-server/src/main/java/nexters/payout/apiserver/stock/application/dto/response/StockShareResponse.java
@@ -10,7 +10,7 @@ public record StockShareResponse(
         Integer share
 ) {
 
-    public static StockShareResponse from(StockShare stockShare) {
+    public static StockShareResponse from(final StockShare stockShare) {
         return new StockShareResponse(
                 StockResponse.from(stockShare.stock()),
                 stockShare.share()

--- a/api-server/src/main/java/nexters/payout/apiserver/stock/application/dto/response/UpcomingDividendResponse.java
+++ b/api-server/src/main/java/nexters/payout/apiserver/stock/application/dto/response/UpcomingDividendResponse.java
@@ -17,7 +17,7 @@ public record UpcomingDividendResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         Instant exDividendDate
 ) {
-    public static UpcomingDividendResponse of(Stock stock, Dividend dividend) {
+    public static UpcomingDividendResponse of(final Stock stock, final Dividend dividend) {
         return new UpcomingDividendResponse(
                 stock.getId(),
                 stock.getTicker(),

--- a/api-server/src/main/java/nexters/payout/apiserver/stock/presentation/StockController.java
+++ b/api-server/src/main/java/nexters/payout/apiserver/stock/presentation/StockController.java
@@ -38,7 +38,8 @@ public class StockController implements StockControllerDocs {
 
     @PostMapping("/sector-ratio")
     public ResponseEntity<List<SectorRatioResponse>> findSectorRatios(
-            @Valid @RequestBody final SectorRatioRequest request) {
+            @Valid @RequestBody final SectorRatioRequest request
+    ) {
         return ResponseEntity.ok(stockQueryService.analyzeSectorRatio(request));
     }
 

--- a/api-server/src/test/java/nexters/payout/apiserver/dividend/common/GivenFixtureTest.java
+++ b/api-server/src/test/java/nexters/payout/apiserver/dividend/common/GivenFixtureTest.java
@@ -47,7 +47,7 @@ public abstract class GivenFixtureTest {
                         eq(ticker),
                         eq(InstantProvider.getLastYear()),
                         eq(month)))
-                        .willReturn(List.of(DividendFixture.createDividendWithExDividendDate(
+                        .willReturn(List.of(DividendFixture.createDividend(
                                 stock.getId(),
                                 dividend,
                                 parseDate(InstantProvider.getLastYear(), month)
@@ -69,7 +69,7 @@ public abstract class GivenFixtureTest {
 
         List<Dividend> dividends = new ArrayList<>();
         for (int month : cycle) {
-            dividends.add(DividendFixture.createDividendWithExDividendDate(
+            dividends.add(DividendFixture.createDividend(
                     stock.getId(),
                     dividend,
                     parseDate(InstantProvider.getLastYear(), month)));

--- a/api-server/src/test/java/nexters/payout/apiserver/dividend/presentation/DividendControllerTest.java
+++ b/api-server/src/test/java/nexters/payout/apiserver/dividend/presentation/DividendControllerTest.java
@@ -150,7 +150,7 @@ class DividendControllerTest extends IntegrationTest {
                         .mapToDouble(MonthlyDividendResponse::totalDividend)
                         .sum())
                         .isEqualTo(expected),
-                () -> assertThat(actual.get(5).dividends().size()).isEqualTo(2)
+                () -> assertThat(actual).hasSize(12)
         );
     }
 

--- a/api-server/src/test/java/nexters/payout/apiserver/dividend/presentation/DividendControllerTest.java
+++ b/api-server/src/test/java/nexters/payout/apiserver/dividend/presentation/DividendControllerTest.java
@@ -299,15 +299,15 @@ class DividendControllerTest extends IntegrationTest {
         Stock aapl = stockRepository.save(StockFixture.createStock(AAPL, Sector.TECHNOLOGY));
         Stock tsla = stockRepository.save(StockFixture.createStock(TSLA, Sector.CONSUMER_CYCLICAL));
 
-        dividendRepository.save(DividendFixture.createDividendWithExDividendDate(
+        dividendRepository.save(DividendFixture.createDividend(
                 aapl.getId(),
                 2.5,
                 parseDate(InstantProvider.getLastYear(), 1)));
-        dividendRepository.save(DividendFixture.createDividendWithExDividendDate(
+        dividendRepository.save(DividendFixture.createDividend(
                 aapl.getId(),
                 2.5,
                 parseDate(InstantProvider.getLastYear(), 6)));
-        dividendRepository.save(DividendFixture.createDividendWithExDividendDate(
+        dividendRepository.save(DividendFixture.createDividend(
                 tsla.getId(),
                 3.0,
                 parseDate(InstantProvider.getLastYear(), 6)));

--- a/api-server/src/test/java/nexters/payout/apiserver/stock/application/StockQueryServiceTest.java
+++ b/api-server/src/test/java/nexters/payout/apiserver/stock/application/StockQueryServiceTest.java
@@ -16,7 +16,7 @@ import nexters.payout.domain.stock.infra.dto.StockDividendDto;
 import nexters.payout.domain.stock.domain.Sector;
 import nexters.payout.domain.stock.domain.Stock;
 import nexters.payout.domain.stock.domain.repository.StockRepository;
-import nexters.payout.domain.stock.domain.service.DividendAnalysisService;
+import nexters.payout.domain.stock.domain.service.StockDividendAnalysisService;
 import nexters.payout.domain.stock.domain.service.SectorAnalysisService;
 import nexters.payout.domain.stock.infra.dto.StockDividendYieldDto;
 import org.junit.jupiter.api.Test;
@@ -53,7 +53,7 @@ class StockQueryServiceTest {
     @Spy
     private SectorAnalysisService sectorAnalysisService;
     @Spy
-    private DividendAnalysisService dividendAnalysisService;
+    private StockDividendAnalysisService stockDividendAnalysisService;
 
     @Test
     void 검색된_종목_정보를_정상적으로_반환한다() {

--- a/api-server/src/test/java/nexters/payout/apiserver/stock/application/StockQueryServiceTest.java
+++ b/api-server/src/test/java/nexters/payout/apiserver/stock/application/StockQueryServiceTest.java
@@ -80,7 +80,7 @@ class StockQueryServiceTest {
         Double expectedPrice = 2.0;
         Double expectedDividend = 0.5;
         Stock aapl = StockFixture.createStock(AAPL, Sector.TECHNOLOGY, 2.0);
-        Dividend dividend = DividendFixture.createDividendWithExDividendDate(aapl.getId(), 0.5, exDividendDate);
+        Dividend dividend = DividendFixture.createDividend(aapl.getId(), 0.5, exDividendDate);
 
         given(stockRepository.findByTicker(any())).willReturn(Optional.of(aapl));
         given(dividendRepository.findAllByStockId(any())).willReturn(List.of(dividend));
@@ -156,7 +156,7 @@ class StockQueryServiceTest {
     void 배당락일이_다가오는_주식_리스트를_가져온다() {
         // given
         Stock stock = StockFixture.createStock(AAPL, TECHNOLOGY);
-        Dividend expected = DividendFixture.createDividendWithPaymentDate(stock.getId(), LocalDateTime.now().plusDays(1).toInstant(UTC));
+        Dividend expected = DividendFixture.createDividendWithExDividendDate(stock.getId(), LocalDateTime.now().plusDays(1).toInstant(UTC));
         given(stockRepository.findUpcomingDividendStock(1, 10))
                 .willReturn(List.of(new StockDividendDto(stock, expected)));
 

--- a/api-server/src/test/java/nexters/payout/apiserver/stock/presentation/integration/StockControllerTest.java
+++ b/api-server/src/test/java/nexters/payout/apiserver/stock/presentation/integration/StockControllerTest.java
@@ -332,7 +332,7 @@ class StockControllerTest extends IntegrationTest {
     void 배당락일이_다가오는_주식_리스트를_가져온다() {
         // given
         Stock aapl = stockRepository.save(StockFixture.createStock(AAPL, Sector.TECHNOLOGY, 5.0));
-        dividendRepository.save(DividendFixture.createDividendWithExDividendDate(
+        dividendRepository.save(DividendFixture.createDividend(
                 aapl.getId(),
                 25.0,
                 LocalDateTime.now().plusDays(1).toInstant(UTC)
@@ -366,12 +366,12 @@ class StockControllerTest extends IntegrationTest {
         // given
         Stock aapl = stockRepository.save(StockFixture.createStock(AAPL, Sector.TECHNOLOGY, 5.0));
         Stock tsla = stockRepository.save(StockFixture.createStock(TSLA, Sector.TECHNOLOGY, 5.0));
-        dividendRepository.save(DividendFixture.createDividendWithExDividendDate(
+        dividendRepository.save(DividendFixture.createDividend(
                 aapl.getId(),
                 25.0,
                 LocalDateTime.now().plusDays(2).toInstant(UTC)
         ));
-        dividendRepository.save(DividendFixture.createDividendWithExDividendDate(
+        dividendRepository.save(DividendFixture.createDividend(
                 tsla.getId(),
                 30.0,
                 LocalDateTime.now().plusDays(1).toInstant(UTC)
@@ -405,22 +405,22 @@ class StockControllerTest extends IntegrationTest {
         // given
         Stock aapl = stockRepository.save(StockFixture.createStock(AAPL, Sector.TECHNOLOGY, 8.0));
         Stock tsla = stockRepository.save(StockFixture.createStock(TSLA, Sector.TECHNOLOGY, 20.0));
-        dividendRepository.save(DividendFixture.createDividendWithExDividendDate(
+        dividendRepository.save(DividendFixture.createDividend(
                 aapl.getId(),
                 8.0,
                 LocalDate.of(InstantProvider.getLastYear(), 3, 1).atStartOfDay().toInstant(UTC)
         ));
-        dividendRepository.save(DividendFixture.createDividendWithExDividendDate(
+        dividendRepository.save(DividendFixture.createDividend(
                 tsla.getId(),
                 5.0,
                 LocalDate.of(InstantProvider.getLastYear(), 3, 1).atStartOfDay().toInstant(UTC)
         ));
-        dividendRepository.save(DividendFixture.createDividendWithExDividendDate(
+        dividendRepository.save(DividendFixture.createDividend(
                 tsla.getId(),
                 5.0,
                 LocalDate.of(InstantProvider.getLastYear(), 6, 1).atStartOfDay().toInstant(UTC)
         ));
-        dividendRepository.save(DividendFixture.createDividendWithExDividendDate(
+        dividendRepository.save(DividendFixture.createDividend(
                 tsla.getId(),
                 5.0,
                 LocalDate.of(InstantProvider.getLastYear() - 1, 6, 1).atStartOfDay().toInstant(UTC)
@@ -455,7 +455,7 @@ class StockControllerTest extends IntegrationTest {
         // given
         Stock aapl = stockRepository.save(StockFixture.createStock(AAPL, Sector.TECHNOLOGY, 5.0));
         stockRepository.save(StockFixture.createStock(TSLA, Sector.TECHNOLOGY, 0.0));
-        dividendRepository.save(DividendFixture.createDividendWithExDividendDate(
+        dividendRepository.save(DividendFixture.createDividend(
                 aapl.getId(),
                 5.0,
                 LocalDate.of(InstantProvider.getLastYear(), 3, 1).atStartOfDay().toInstant(UTC)

--- a/batch/src/main/java/nexters/payout/batch/application/FinancialClient.java
+++ b/batch/src/main/java/nexters/payout/batch/application/FinancialClient.java
@@ -43,6 +43,5 @@ public interface FinancialClient {
             Instant paymentDate,
             Instant declarationDate
     ) {
-
     }
 }

--- a/batch/src/main/java/nexters/payout/batch/infra/fmp/FmpFinancialClient.java
+++ b/batch/src/main/java/nexters/payout/batch/infra/fmp/FmpFinancialClient.java
@@ -2,6 +2,7 @@ package nexters.payout.batch.infra.fmp;
 
 import lombok.extern.slf4j.Slf4j;
 import nexters.payout.batch.application.FinancialClient;
+import nexters.payout.core.time.DateFormat;
 import nexters.payout.core.time.InstantProvider;
 import nexters.payout.domain.stock.domain.Exchange;
 import nexters.payout.domain.stock.domain.Sector;
@@ -24,6 +25,7 @@ import static nexters.payout.domain.stock.domain.Sector.ETF;
 @Slf4j
 @Service
 public class FmpFinancialClient implements FinancialClient {
+
     private final WebClient fmpWebClient;
     private final FmpProperties fmpProperties;
     private final static int MAX_LIMIT = 1000000;
@@ -118,9 +120,6 @@ public class FmpFinancialClient implements FinancialClient {
                 .block();
     }
 
-    /**
-     * 과거 배당금 관련 정보를 가져오는 메서드입니다.
-     */
     @Override
     public List<DividendData> getPastDividendList() {
 
@@ -151,9 +150,6 @@ public class FmpFinancialClient implements FinancialClient {
         return result;
     }
 
-    /**
-     * 다가오는 배당금 관련 정보를 가져오는 메서드입니다.
-     */
     @Override
     public List<DividendData> getUpcomingDividendList() {
 
@@ -177,7 +173,7 @@ public class FmpFinancialClient implements FinancialClient {
                 .uri(uriBuilder ->
                         uriBuilder
                                 .path(fmpProperties.getStockDividendCalenderPath())
-                                .queryParam("to", formatInstant(date))
+                                .queryParam("to", DateFormat.formatInstant(date))
                                 .queryParam("apikey", fmpProperties.getApiKey())
                                 .build())
                 .retrieve()
@@ -195,8 +191,8 @@ public class FmpFinancialClient implements FinancialClient {
                 .uri(uriBuilder ->
                         uriBuilder
                                 .path(fmpProperties.getStockDividendCalenderPath())
-                                .queryParam("from", formatInstant(from))
-                                .queryParam("to", formatInstant(to))
+                                .queryParam("from", DateFormat.formatInstant(from))
+                                .queryParam("to", DateFormat.formatInstant(to))
                                 .queryParam("apikey", fmpProperties.getApiKey())
                                 .build())
                 .retrieve()
@@ -207,14 +203,5 @@ public class FmpFinancialClient implements FinancialClient {
                 })
                 .collectList()
                 .block();
-    }
-
-    /**
-     * Instant를 "yyyy-MM-dd" 형식의 String으로 변환합니다.
-     */
-    private String formatInstant(Instant instant) {
-
-        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
-        return formatter.format(Date.from(instant));
     }
 }

--- a/batch/src/main/java/nexters/payout/batch/infra/ninjas/NinjasDto.java
+++ b/batch/src/main/java/nexters/payout/batch/infra/ninjas/NinjasDto.java
@@ -5,5 +5,4 @@ record NinjasStockLogo(
         String ticker,
         String image
 ) {
-
 }

--- a/batch/src/test/java/nexters/payout/batch/application/DividendBatchServiceTest.java
+++ b/batch/src/test/java/nexters/payout/batch/application/DividendBatchServiceTest.java
@@ -47,7 +47,7 @@ class DividendBatchServiceTest extends AbstractBatchServiceTest {
 
         // given
         Stock stock = stockRepository.save(StockFixture.createStock(AAPL, 12.51, 120000));
-        Dividend expected = DividendFixture.createDividendWithPaymentDate(stock.getId());
+        Dividend expected = DividendFixture.createDividend(stock.getId());
 
         List<FinancialClient.DividendData> responses = new ArrayList<>();
         responses.add(new FinancialClient.DividendData(
@@ -126,7 +126,7 @@ class DividendBatchServiceTest extends AbstractBatchServiceTest {
         // given
         given(dateTimeProvider.getNow()).willReturn(Optional.of(LocalDateTime.now().minusDays(1)));
         Stock stock = stockRepository.save(StockFixture.createStock(AAPL, 12.51, 120000));
-        dividendRepository.save(DividendFixture.createDividendWithExDividendDate(
+        dividendRepository.save(DividendFixture.createDividend(
                 stock.getId(),
                 21.02,
                 LocalDateTime.now().toInstant(UTC)));
@@ -145,7 +145,7 @@ class DividendBatchServiceTest extends AbstractBatchServiceTest {
     void 새로운_미래_배당금_정보를_생성한다() {
         // given
         Stock stock = stockRepository.save(StockFixture.createStock(AAPL, 12.51, 120000));
-        Dividend expected = DividendFixture.createDividendWithPaymentDate(stock.getId());
+        Dividend expected = DividendFixture.createDividend(stock.getId());
         Instant expectedDate = LocalDateTime.now().plusDays(1).toInstant(UTC);
 
         List<FinancialClient.DividendData> responses = new ArrayList<>();

--- a/core/src/main/java/nexters/payout/core/time/DateFormat.java
+++ b/core/src/main/java/nexters/payout/core/time/DateFormat.java
@@ -1,6 +1,8 @@
 package nexters.payout.core.time;
 
+import java.text.SimpleDateFormat;
 import java.time.Instant;
+import java.util.Date;
 
 public class DateFormat {
     /**
@@ -10,5 +12,14 @@ public class DateFormat {
 
         if (date == null) return null;
         return Instant.parse(date + "T00:00:00Z");
+    }
+
+    /**
+     * Instant를 "yyyy-MM-dd" 형식의 String으로 변환합니다.
+     */
+    public static String formatInstant(Instant instant) {
+
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+        return formatter.format(Date.from(instant));
     }
 }

--- a/core/src/main/java/nexters/payout/core/time/InstantProvider.java
+++ b/core/src/main/java/nexters/payout/core/time/InstantProvider.java
@@ -1,15 +1,33 @@
 package nexters.payout.core.time;
 
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.*;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.time.ZoneOffset.UTC;
 
 public class InstantProvider {
     public static LocalDate toLocalDate(Instant instant) {
         return LocalDate.ofInstant(instant, UTC);
+    }
+
+    public static List<YearMonth> getNext12MonthsYearMonth() {
+        YearMonth startYearMonth = getThisYearMonth();
+        YearMonth endYearMonth = getAfterYearMonth(11);
+
+        return Stream.iterate(startYearMonth, date -> date.plusMonths(1))
+                .limit(startYearMonth.until(endYearMonth, ChronoUnit.MONTHS) + 1)
+                .collect(Collectors.toList());
+    }
+
+    public static YearMonth getThisYearMonth() {
+        return YearMonth.of(getNow().getYear(), getNow().getMonth());
+    }
+
+    public static YearMonth getAfterYearMonth(int month) {
+        return YearMonth.of(getNow().plusMonths(month).getYear(), getNow().plusMonths(month).getMonthValue());
     }
 
     public static Integer getThisYear() {

--- a/core/src/main/java/nexters/payout/core/time/InstantProvider.java
+++ b/core/src/main/java/nexters/payout/core/time/InstantProvider.java
@@ -13,7 +13,7 @@ public class InstantProvider {
         return LocalDate.ofInstant(instant, UTC);
     }
 
-    public static List<YearMonth> getNext12MonthsYearMonth() {
+    public static List<YearMonth> generateNext12Months() {
         YearMonth startYearMonth = getThisYearMonth();
         YearMonth endYearMonth = getAfterYearMonth(11);
 

--- a/domain/src/main/java/nexters/payout/domain/stock/domain/service/StockDividendAnalysisService.java
+++ b/domain/src/main/java/nexters/payout/domain/stock/domain/service/StockDividendAnalysisService.java
@@ -11,7 +11,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 @DomainService
-public class DividendAnalysisService {
+public class StockDividendAnalysisService {
     /**
      * 작년 데이터를 기반으로 배당을 주었던 월 리스트를 계산합니다.
      */
@@ -77,5 +77,13 @@ public class DividendAnalysisService {
     private boolean isCurrentOrFutureDate(final LocalDate date) {
         LocalDate now = InstantProvider.getNow();
         return date.isEqual(now) || date.isAfter(InstantProvider.getNow());
+    }
+
+    public Double calculateAverageDividend(final List<Dividend> dividends) {
+        return dividends
+                .stream()
+                .mapToDouble(Dividend::getDividend)
+                .average()
+                .orElse(0.0);
     }
 }

--- a/domain/src/test/java/nexters/payout/domain/stock/service/StockDividendAnalysisServiceTest.java
+++ b/domain/src/test/java/nexters/payout/domain/stock/service/StockDividendAnalysisServiceTest.java
@@ -5,7 +5,7 @@ import nexters.payout.domain.StockFixture;
 import nexters.payout.domain.dividend.domain.Dividend;
 import nexters.payout.domain.stock.domain.Sector;
 import nexters.payout.domain.stock.domain.Stock;
-import nexters.payout.domain.stock.domain.service.DividendAnalysisService;
+import nexters.payout.domain.stock.domain.service.StockDividendAnalysisService;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -20,9 +20,9 @@ import java.util.UUID;
 import static java.time.ZoneOffset.UTC;
 import static org.assertj.core.api.Assertions.assertThat;
 
-class DividendAnalysisServiceTest {
+class StockDividendAnalysisServiceTest {
 
-    DividendAnalysisService dividendAnalysisService = new DividendAnalysisService();
+    StockDividendAnalysisService stockDividendAnalysisService = new StockDividendAnalysisService();
 
     @Test
     void 작년_배당_월_리스트를_정상적으로_반환한다() {
@@ -40,7 +40,7 @@ class DividendAnalysisServiceTest {
         Dividend fakeDividend = DividendFixture.createDividendWithPaymentDate(stock.getId(), fakePaymentDate);
 
         // when
-        List<Month> actual = dividendAnalysisService.calculateDividendMonths(stock, List.of(janDividend, aprDividend, julDividend, fakeDividend));
+        List<Month> actual = stockDividendAnalysisService.calculateDividendMonths(stock, List.of(janDividend, aprDividend, julDividend, fakeDividend));
 
         // then
         assertThat(actual).isEqualTo(List.of(Month.JANUARY, Month.APRIL, Month.JULY));
@@ -55,7 +55,7 @@ class DividendAnalysisServiceTest {
         Dividend fakeDividend = DividendFixture.createDividendWithPaymentDate(stock.getId(), fakePaymentDate);
 
         // when
-        List<Month> actual = dividendAnalysisService.calculateDividendMonths(stock, List.of(fakeDividend));
+        List<Month> actual = stockDividendAnalysisService.calculateDividendMonths(stock, List.of(fakeDividend));
 
         // then
         assertThat(actual).isEmpty();
@@ -67,7 +67,7 @@ class DividendAnalysisServiceTest {
         Stock stock = StockFixture.createStock(StockFixture.AAPL, Sector.TECHNOLOGY);
 
         // when
-        List<Month> actual = dividendAnalysisService.calculateDividendMonths(stock, List.of());
+        List<Month> actual = stockDividendAnalysisService.calculateDividendMonths(stock, List.of());
 
         // then
         assertThat(actual).isEmpty();
@@ -92,7 +92,7 @@ class DividendAnalysisServiceTest {
         List<Dividend> lastYearDividends = List.of(pastDividend, earlistDividend);
 
         // when
-        Optional<Dividend> actual = dividendAnalysisService.findUpcomingDividend(lastYearDividends, Collections.emptyList());
+        Optional<Dividend> actual = stockDividendAnalysisService.findUpcomingDividend(lastYearDividends, Collections.emptyList());
 
         // then
         assertThat(actual.get()).isEqualTo(earlistDividend);
@@ -122,7 +122,7 @@ class DividendAnalysisServiceTest {
         List<Dividend> thisYearDividends = List.of(thisYearDividend);
 
         // when
-        Optional<Dividend> actual = dividendAnalysisService.findUpcomingDividend(lastYearDividends, thisYearDividends);
+        Optional<Dividend> actual = stockDividendAnalysisService.findUpcomingDividend(lastYearDividends, thisYearDividends);
 
         // then
         assertThat(actual.get()).isEqualTo(thisYearDividend);

--- a/domain/src/testFixtures/java/nexters/payout/domain/DividendFixture.java
+++ b/domain/src/testFixtures/java/nexters/payout/domain/DividendFixture.java
@@ -6,7 +6,8 @@ import java.time.Instant;
 import java.util.UUID;
 
 public class DividendFixture {
-    public static Dividend createDividendWithPaymentDate(UUID stockId, Double dividend) {
+
+    public static Dividend createDividendWithDividend(UUID stockId, Double dividend) {
         return new Dividend(
                 UUID.randomUUID(),
                 stockId,
@@ -17,7 +18,7 @@ public class DividendFixture {
         );
     }
 
-    public static Dividend createDividendWithPaymentDate(UUID stockId, Instant exDividendDate) {
+    public static Dividend createDividendWithExDividendDate(UUID stockId, Instant exDividendDate) {
         return new Dividend(
                 UUID.randomUUID(),
                 stockId,
@@ -37,7 +38,7 @@ public class DividendFixture {
                 paymentDate);
     }
 
-    public static Dividend createDividendWithExDividendDate(UUID stockId, Double dividend, Instant exDividendDate) {
+    public static Dividend createDividend(UUID stockId, Double dividend, Instant exDividendDate) {
         return new Dividend(
                 UUID.randomUUID(),
                 stockId,
@@ -47,7 +48,7 @@ public class DividendFixture {
                 exDividendDate);
     }
 
-    public static Dividend createDividendWithPaymentDate(UUID stockId) {
+    public static Dividend createDividend(UUID stockId) {
         return new Dividend(
                 UUID.randomUUID(),
                 stockId,


### PR DESCRIPTION
### Issue Number

close: #71 

### 작업 내역
전체적인 코드 정리 및 추가로 발견한 엣지 케이스(**지나간 배당락일은 있지만 다가오는 배당락일이 없는 경우**)에 대한 기능 구현하였습니다~!

그리고 이번 PR과는 관련 없지만 월별 배당금 조회 API에서 모든 해가 2025년으로 나오는데 월,일만 나오기 때문에 연도를 고려하지 않으신걸까요? 또는 버그인지 궁금합니닷

-----
+) 이거 저희 월별 배당금 버그 고치면서 연도도 제대로 나오도록 같이 수정했는데 맞을까요?? 혹시 아니라면 요 PR 에서 말씀주세요!


> 구현 내용 및 작업 했던 내역

- [x] 전체적인 코드 리팩터링 진행
- [x] 주식 종목 상세 조회시 엣지 케이스 고려해 코드 수정
- [x] 월별 배당금 조회 API 버그 수정

### 변경사항

- 의존성 목록

### PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점

- 특이 사항 1
- 특이 사항 2
